### PR TITLE
Add CI workflow with Prettier and Playwright tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,60 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Rust
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+
+      - name: Cache cargo
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: ${{ runner.os }}-cargo-
+
+      - name: Install wasm target
+        run: rustup target add wasm32-unknown-unknown
+
+      - name: Build server
+        run: cargo build -p server --release
+
+      - name: Build wasm client
+        run: cargo build -p client --target wasm32-unknown-unknown --release
+
+      - name: Run tests
+        run: cargo test --workspace
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: "npm"
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run Prettier
+        run: npm run prettier
+
+      - name: Install Playwright browsers
+        run: npx playwright install --with-deps
+
+      - name: Run Playwright tests
+        run: npx playwright test --reporter=list

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "scripts": {
     "format": "prettier --write .",
     "lint": "prettier --check .",
+    "prettier": "prettier --check .",
     "prepare": "husky install"
   },
   "devDependencies": {


### PR DESCRIPTION
## Summary
- add `prettier` npm script
- add GitHub Actions workflow to build server and WASM client, run tests, check formatting, and execute Playwright tests with caching

## Testing
- `npm run prettier`
- `cargo test` *(fails: no variant or associated item named `Digit1` in `bevy::prelude::KeyCode`)*

------
https://chatgpt.com/codex/tasks/task_e_68bc2897881c8323ab33d11d06800d03