### PR TITLE
feat(server): add cross-origin security headers

### DIFF
--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -5,7 +5,7 @@ use axum::{
         ws::{WebSocket, WebSocketUpgrade},
         State,
     },
-    http::{header::CACHE_CONTROL, HeaderValue, StatusCode},
+    http::{header::CACHE_CONTROL, HeaderName, HeaderValue, StatusCode},
     response::IntoResponse,
     routing::{get, get_service},
     Router,
@@ -78,18 +78,29 @@ async fn main() {
 
     let state = Arc::new(AppState { db, email });
 
-    let assets_service = get_service(ServeDir::new("assets")).layer(
-        SetResponseHeaderLayer::if_not_present(
+    let assets_service =
+        get_service(ServeDir::new("assets")).layer(SetResponseHeaderLayer::if_not_present(
             CACHE_CONTROL,
             HeaderValue::from_static("public, max-age=31536000, immutable"),
-        ),
-    );
+        ));
 
     let app = Router::new()
         .nest("/auth", auth_routes())
         .route("/ws", get(ws_handler))
         .nest_service("/assets", assets_service)
         .fallback_service(ServeDir::new("static"))
+        .layer(SetResponseHeaderLayer::if_not_present(
+            HeaderName::from_static("cross-origin-opener-policy"),
+            HeaderValue::from_static("same-origin"),
+        ))
+        .layer(SetResponseHeaderLayer::if_not_present(
+            HeaderName::from_static("cross-origin-embedder-policy"),
+            HeaderValue::from_static("require-corp"),
+        ))
+        .layer(SetResponseHeaderLayer::if_not_present(
+            HeaderName::from_static("cross-origin-resource-policy"),
+            HeaderValue::from_static("same-origin"),
+        ))
         .with_state(state);
 
     let addr = SocketAddr::from(([0, 0, 0, 0], 3000));


### PR DESCRIPTION
## Summary
- add Cross-Origin headers via `SetResponseHeaderLayer`

## Testing
- `npm run prettier`
- `cargo test -p server` *(fails: email::tests::invalid_address, email::tests::rate_limiting)*
- `curl -I http://localhost:3000/`
- `curl -I http://localhost:3000/assets/test.txt`

------
https://chatgpt.com/codex/tasks/task_e_68bc301f9cbc832394333498aa7c3c1e