### PR TITLE
feat: introduce platform api and modular engine

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2051,6 +2051,7 @@ dependencies = [
  "bevy_egui",
  "duck_hunt",
  "engine",
+ "platform-api",
  "reqwest",
  "serde",
  "serde_json",
@@ -2526,7 +2527,7 @@ name = "duck_hunt"
 version = "0.1.0"
 dependencies = [
  "bevy 0.12.1",
- "engine",
+ "platform-api",
 ]
 
 [[package]]
@@ -2676,6 +2677,7 @@ name = "engine"
 version = "0.1.0"
 dependencies = [
  "bevy 0.12.1",
+ "platform-api",
 ]
 
 [[package]]
@@ -4977,6 +4979,14 @@ name = "pkg-config"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
+
+[[package]]
+name = "platform-api"
+version = "0.1.0"
+dependencies = [
+ "bevy 0.12.1",
+ "bitflags 2.9.4",
+]
 
 [[package]]
 name = "png"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,5 +4,6 @@ members = [
     "server",
     "client",
     "crates/net",
-    "xtask"
+    "crates/platform-api",
+    "xtask",
 ]

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -12,4 +12,5 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 engine = { path = "crates/engine" }
 duck_hunt = { path = "crates/minigames/duck_hunt" }
+platform-api = { path = "../crates/platform-api" }
 wasm-bindgen-futures = "0.4"

--- a/client/crates/minigames/duck_hunt/Cargo.toml
+++ b/client/crates/minigames/duck_hunt/Cargo.toml
@@ -5,4 +5,4 @@ edition = "2021"
 
 [dependencies]
 bevy = "0.12"
-engine = { path = "../../engine" }
+platform-api = { path = "../../../../crates/platform-api" }

--- a/client/crates/minigames/duck_hunt/src/lib.rs
+++ b/client/crates/minigames/duck_hunt/src/lib.rs
@@ -1,6 +1,7 @@
 use bevy::prelude::*;
-use engine::{AppState, Minigame, MinigameInfo};
+use platform_api::{AppState, CapabilityFlags, GameModule, ModuleMetadata};
 
+#[derive(Default)]
 pub struct DuckHuntPlugin;
 
 impl Plugin for DuckHuntPlugin {
@@ -35,11 +36,12 @@ fn cleanup(mut commands: Commands, q: Query<Entity, With<DuckHuntEntity>>) {
     }
 }
 
-impl Minigame for DuckHuntPlugin {
-    fn info() -> MinigameInfo {
-        MinigameInfo {
+impl GameModule for DuckHuntPlugin {
+    fn metadata() -> ModuleMetadata {
+        ModuleMetadata {
             name: "Duck Hunt",
             state: AppState::DuckHunt,
+            capabilities: CapabilityFlags::LOBBY_PAD,
         }
     }
 }

--- a/client/src/main.rs
+++ b/client/src/main.rs
@@ -36,6 +36,6 @@ fn main() {
     App::new()
         .add_plugins(DefaultPlugins)
         .add_plugins(EnginePlugin)
-        .add_minigame::<DuckHuntPlugin>()
+        .add_game_module::<DuckHuntPlugin>()
         .run();
 }

--- a/crates/platform-api/Cargo.toml
+++ b/crates/platform-api/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
-name = "engine"
+name = "platform-api"
 version = "0.1.0"
 edition = "2021"
 
 [dependencies]
 bevy = "0.12"
-platform-api = { path = "../../../crates/platform-api" }
+bitflags = "2"

--- a/crates/platform-api/src/lib.rs
+++ b/crates/platform-api/src/lib.rs
@@ -1,0 +1,32 @@
+use bevy::prelude::*;
+use bitflags::bitflags;
+
+#[derive(States, Default, Clone, Eq, PartialEq, Hash, Debug)]
+pub enum AppState {
+    #[default]
+    Lobby,
+    DuckHunt,
+}
+
+bitflags! {
+    #[derive(Default, Debug, Clone, Copy, PartialEq, Eq, Hash)]
+    pub struct CapabilityFlags: u32 {
+        const LOBBY_PAD = 0b0001;
+    }
+}
+
+#[derive(Clone)]
+pub struct ModuleMetadata {
+    pub name: &'static str,
+    pub state: AppState,
+    pub capabilities: CapabilityFlags,
+}
+
+pub struct ModuleContext<'a> {
+    pub app: &'a mut App,
+}
+
+pub trait GameModule: Plugin + Sized {
+    fn metadata() -> ModuleMetadata;
+    fn register(_context: &mut ModuleContext) {}
+}


### PR DESCRIPTION
## Summary
- add platform-api crate defining GameModule and capability flags
- swap minigame system for module registry and lobby pad discovery
- wire up duck_hunt as a GameModule and update client registration

## Testing
- `cargo check -p client`
- `npm run prettier`


------
https://chatgpt.com/codex/tasks/task_e_68bc370b8c848323883ecd762cfad689