### PR TITLE
chore: upgrade rust edition

### DIFF
--- a/client/crates/engine/Cargo.toml
+++ b/client/crates/engine/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "engine"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 
 [dependencies]
 bevy = "0.12"

--- a/crates/net/Cargo.toml
+++ b/crates/net/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "net"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 
 [features]
 default = ["webrtc"]

--- a/crates/platform-api/Cargo.toml
+++ b/crates/platform-api/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "platform-api"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 
 [dependencies]
 bevy = "0.12"

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "server"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 
 [dependencies]
 lettre = { version = "0.11", features = ["builder", "smtp-transport"] }

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "xtask"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 
 [dependencies]
 anyhow = "1"


### PR DESCRIPTION
## Summary
- update Rust edition to 2024 across server, client engine, net, platform API, and xtask crates

## Testing
- `npm run prettier`
- `cargo check --workspace` *(fails: trait bounds errors in crates/net)*

------
https://chatgpt.com/codex/tasks/task_e_68bc3a775c148323858e08d3b0cb04cf