### PR TITLE
chore: update auth base URL

### DIFF
--- a/client/src/main.rs
+++ b/client/src/main.rs
@@ -6,7 +6,7 @@ use reqwest::Client;
 use serde_json::json;
 use wasm_bindgen_futures::spawn_local;
 
-const AUTH_BASE_URL: &str = "http://localhost:8000/auth";
+const AUTH_BASE_URL: &str = "http://localhost:3000/auth";
 
 #[derive(Resource, Clone)]
 struct SessionClient {


### PR DESCRIPTION
## Summary
- point client auth base URL to port 3000

## Testing
- `npm run prettier`
- `cargo build --manifest-path client/Cargo.toml` (fails: none, built successfully)
- `cargo build --manifest-path server/Cargo.toml`
- `DATABASE_URL=postgres://localhost/test SMTP_SERVER=foo SMTP_USERNAME=foo SMTP_PASSWORD=foo EMAIL_FROM=foo@bar cargo run --manifest-path server/Cargo.toml` *(fails: failed to connect to database: PoolTimedOut)*

------
https://chatgpt.com/codex/tasks/task_e_68bc3c999c6c832399d9b2922dcf8364