### PR TITLE
feat: expand module metadata and lifecycle

### DIFF
--- a/crates/platform-api/src/lib.rs
+++ b/crates/platform-api/src/lib.rs
@@ -15,18 +15,43 @@ bitflags! {
     }
 }
 
+/// Describes a game module and its capabilities.
 #[derive(Clone)]
 pub struct ModuleMetadata {
+    /// Unique string identifier for the module.
+    pub id: &'static str,
+    /// Human-readable name shown to players.
     pub name: &'static str,
+    /// Semver-style version string.
+    pub version: &'static str,
+    /// Name of the author or organization.
+    pub author: &'static str,
+    /// The [`AppState`] associated with the module.
     pub state: AppState,
+    /// Feature flags implemented by the module.
     pub capabilities: CapabilityFlags,
 }
 
+/// Context handed to module hooks giving access to the Bevy [`World`].
 pub struct ModuleContext<'a> {
-    pub app: &'a mut App,
+    /// Mutable reference to the game world.
+    pub world: &'a mut World,
 }
 
+/// Common interface implemented by all game modules.
 pub trait GameModule: Plugin + Sized {
+    /// Compile-time identifier for the module.
+    const ID: &'static str;
+
+    /// Returns static metadata describing the module.
     fn metadata() -> ModuleMetadata;
-    fn register(_context: &mut ModuleContext) {}
+
+    /// Invoked when the server initializes the module.
+    fn server_register(_context: &mut ModuleContext) {}
+
+    /// Called whenever the engine transitions into the module's state.
+    fn enter(_context: &mut ModuleContext) {}
+
+    /// Called whenever the engine leaves the module's state.
+    fn exit(_context: &mut ModuleContext) {}
 }


### PR DESCRIPTION
## Summary
- expand ModuleMetadata with identifiers and author info
- add lifecycle hooks and ID constant to GameModule
- wire engine and Duck Hunt module to new API

## Testing
- `npm run prettier`
- `cargo test -p platform-api -p engine -p duck_hunt`

------
https://chatgpt.com/codex/tasks/task_e_68bc40e7f8888323b08757545c02fdc8