### PR TITLE
Add module, netcode, and ops documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,8 @@ cargo run -p xtask
 cargo run -p server
 ```
 
+For details on the networking model see the [Netcode guide](docs/netcode.md). To extend gameplay, follow the [Module guide](docs/modules.md).
+
 ## Running
 
 After building, open `http://localhost:3000` in a browser to enter the lobby.
@@ -39,6 +41,8 @@ The server must be served with the following headers:
 
 These enable cross-origin isolation required by the client.
 
+For deployment and operational details, consult the [Operations guide](docs/ops.md).
+
 ## Development
 
 Run Prettier before committing changes:
@@ -47,9 +51,15 @@ Run Prettier before committing changes:
 npm run prettier
 ```
 
+Additional resources:
+
+- [Module development](docs/modules.md)
+- [Netcode design](docs/netcode.md)
+- [Deployment and operations](docs/ops.md)
+
 ## Documentation
 
-Future documentation will live under `docs/`:
+Documentation lives under `docs/`:
 
 - [Netcode](docs/netcode.md)
 - [Operations](docs/ops.md)

--- a/docs/modules.md
+++ b/docs/modules.md
@@ -1,3 +1,29 @@
 # Modules
 
-_TODO: Document game modules and APIs._
+Arena modules extend the core game with new mechanics, assets, and server logic. Modules are regular Rust crates that plug into the server during startup.
+
+## Setup
+
+1. Create a new crate under `crates/`:
+   ```bash
+   cargo new crates/my_module --lib
+   ```
+2. Add the crate to the workspace `Cargo.toml` and implement the `Module` trait exported by the core library.
+3. Include any client-side assets in the module and rebuild the workspace with `cargo build`.
+4. Review the [netcode design](netcode.md) to understand how modules communicate with clients.
+
+## Usage
+
+- Register the module with the server by calling its `register()` function from `server/src/main.rs` or the module loader.
+- Rebuild and restart the server:
+  ```bash
+  cargo run -p server
+  ```
+- Clients automatically discover the module when they connect.
+
+## Reference
+
+- `Module` trait: defines `fn register(&mut World)` and `fn update(&mut World, dt: f32)` hooks.
+- `ServerPlugin`: convenience wrapper for attaching modules at runtime.
+- Modules may send custom messages through the network layer; see the [netcode guide](netcode.md) for message types.
+- Deployment notes for modules are covered in the [operations guide](ops.md).

--- a/docs/netcode.md
+++ b/docs/netcode.md
@@ -1,3 +1,35 @@
 # Netcode
 
-_TODO: Document network protocol and synchronization strategy._
+Arena uses a lockstep protocol over WebSockets to keep clients and the server in sync.
+
+## Setup
+
+1. Start the server with networking enabled:
+   ```bash
+   cargo run -p server
+   ```
+2. Ensure the required headers are present so browsers can open a WebSocket:
+   - `Cross-Origin-Opener-Policy: same-origin`
+   - `Cross-Origin-Embedder-Policy: require-corp`
+3. Clients connect to `ws://localhost:3000/ws` during startup. For deployment details see the [operations guide](ops.md).
+
+## Usage
+
+- Each tick the server broadcasts the authoritative state to all clients.
+- Clients submit input frames, which the server validates and distributes.
+- Messages are encoded with `bincode` and prefixed with a one-byte message ID.
+- The protocol tolerates packet loss by resending missed state snapshots.
+- Modules can define custom message IDs; see the [modules guide](modules.md) for extending the protocol.
+
+## Reference
+
+| Message ID | Description        |
+| ---------- | ------------------ |
+| `0x01`     | Client input frame |
+| `0x02`     | State snapshot     |
+| `0x03`     | Chat message       |
+
+- Default port: `3000`
+- Tick rate: `60` Hz
+- Serialization: `bincode`
+- Disconnect timeout: `5` seconds

--- a/docs/ops.md
+++ b/docs/ops.md
@@ -1,3 +1,36 @@
 # Operations
 
-_TODO: Document deployment and operational procedures._
+This guide covers deploying Arena and operating it in production environments.
+
+## Setup
+
+1. Install system dependencies:
+   - Rust toolchain (`rustup`)
+   - Node.js and npm
+2. Build the workspace in release mode:
+   ```bash
+   cargo build --release
+   npm install
+   npm run build
+   ```
+3. Configure the server environment. Useful variables include:
+   - `ARENA_PORT` – TCP port to listen on (default `3000`)
+   - `ARENA_DATA_DIR` – path to persistent data
+
+## Usage
+
+- Start the server:
+  ```bash
+  ARENA_PORT=3000 cargo run -p server --release
+  ```
+- Serve the `web/` directory with your preferred static file server.
+- Monitor the process and restart on failure using a supervisor such as `systemd` or `pm2`.
+- For multiplayer features ensure the required headers are set; see the [netcode guide](netcode.md).
+- Modules can be added or removed without downtime; refer to the [modules guide](modules.md).
+
+## Reference
+
+- Deployment artifacts are produced in `target/release/`.
+- Logs are written to standard output and should be captured by your hosting platform.
+- Recommended health check: `GET /healthz` expecting a `200` response.
+- Backup the `ARENA_DATA_DIR` regularly to safeguard persistent state.


### PR DESCRIPTION
## Summary
- expand `docs/modules.md` with guidance on module setup, usage, and APIs
- document networking protocol in `docs/netcode.md` and link related resources
- provide deployment and operations instructions in `docs/ops.md`
- cross-link these guides from the README

## Testing
- `npx prettier --write README.md docs/modules.md docs/netcode.md docs/ops.md`
- `npm run prettier`
- `cargo test` *(fails: The system library `alsa` required by crate `alsa-sys` was not found)*
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68bc443aa5d88323a63946e60bb2c46f