### PR TITLE
feat: expand game module API

### DIFF
--- a/client/crates/engine/src/lib.rs
+++ b/client/crates/engine/src/lib.rs
@@ -256,10 +256,8 @@ fn pad_trigger(
 pub fn register_module<M: GameModule + Default + 'static>(app: &mut App) {
     let info = M::metadata();
     let state = info.state.clone();
-    {
-        let world = &mut app.world;
-        M::server_register(&mut ModuleContext { world });
-    }
+    M::register(app);
+    M::server_register(app);
     app.world
         .get_resource_mut::<ModuleRegistry>()
         .expect("EnginePlugin must be added before registering modules")
@@ -272,12 +270,14 @@ pub fn register_module<M: GameModule + Default + 'static>(app: &mut App) {
 
 /// System wrapper that forwards state entry to the module.
 fn enter_module<M: GameModule>(world: &mut World) {
-    M::enter(&mut ModuleContext { world });
+    let mut ctx = ModuleContext::new(world);
+    M::enter(&mut ctx);
 }
 
 /// System wrapper that forwards state exit to the module.
 fn exit_module<M: GameModule>(world: &mut World) {
-    M::exit(&mut ModuleContext { world });
+    let mut ctx = ModuleContext::new(world);
+    M::exit(&mut ctx);
 }
 
 pub fn hotload_modules(_app: &mut App) {

--- a/client/crates/minigames/duck_hunt/src/lib.rs
+++ b/client/crates/minigames/duck_hunt/src/lib.rs
@@ -1,5 +1,5 @@
 use bevy::prelude::*;
-use platform_api::{AppState, CapabilityFlags, GameModule, ModuleContext, ModuleMetadata};
+use platform_api::{AppState, CapabilityFlags, GameModule, ModuleContext, ModuleMetadata, ServerApp};
 
 #[derive(Default)]
 pub struct DuckHuntPlugin;
@@ -55,13 +55,15 @@ impl GameModule for DuckHuntPlugin {
         }
     }
 
+    fn register(_app: &mut App) {}
+
     fn enter(ctx: &mut ModuleContext) {
-        setup(ctx.world);
+        setup(ctx.world());
     }
 
     fn exit(ctx: &mut ModuleContext) {
-        cleanup(ctx.world);
+        cleanup(ctx.world());
     }
 
-    fn server_register(_ctx: &mut ModuleContext) {}
+    fn server_register(_app: &mut ServerApp) {}
 }

--- a/crates/platform-api/Cargo.toml
+++ b/crates/platform-api/Cargo.toml
@@ -4,5 +4,5 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
-bevy = { version = "0.12", default-features = false, features = ["bevy_winit", "bevy_render", "bevy_core_pipeline", "bevy_pbr", "bevy_ui", "bevy_text", "x11"] }
+bevy = { version = "0.12", default-features = false, features = ["bevy_winit", "bevy_render", "bevy_core_pipeline", "bevy_pbr", "bevy_ui", "bevy_text", "bevy_audio", "x11"] }
 bitflags = "2"


### PR DESCRIPTION
## Summary
- add registration hooks and richer ModuleContext with resource accessors
- extend CapabilityFlags for additional engine features
- call module registration from EnginePlugin and update Duck Hunt module

## Testing
- `cargo test` (platform-api)
- `cargo test` (net)
- `cargo test` (engine)
- `cargo test` (duck_hunt)
- `npm run prettier`


------
https://chatgpt.com/codex/tasks/task_e_68bc4b886bf8832391b24670e67a05d8