### PR TITLE
feat: extend module metadata with capacity and icon

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2571,6 +2571,7 @@ checksum = "75b325c5dbd37f80359721ad39aca5a29fb04c89279657cffdda8736d0c0b9d2"
 name = "duck_hunt"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
  "bevy 0.12.1",
  "platform-api",
 ]
@@ -5121,6 +5122,7 @@ checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 name = "platform-api"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
  "bevy 0.12.1",
  "bitflags 2.9.4",
 ]

--- a/client/crates/engine/src/lib.rs
+++ b/client/crates/engine/src/lib.rs
@@ -316,13 +316,13 @@ pub fn register_module<M: GameModule + Default + 'static>(app: &mut App) {
 /// System wrapper that forwards state entry to the module.
 fn enter_module<M: GameModule>(world: &mut World) {
     let mut ctx = ModuleContext::new(world);
-    M::enter(&mut ctx);
+    M::enter(&mut ctx).expect("module enter failed");
 }
 
 /// System wrapper that forwards state exit to the module.
 fn exit_module<M: GameModule>(world: &mut World) {
     let mut ctx = ModuleContext::new(world);
-    M::exit(&mut ctx);
+    M::exit(&mut ctx).expect("module exit failed");
 }
 
 #[derive(Deserialize)]
@@ -334,6 +334,8 @@ struct ModuleManifest {
     state: String,
     #[serde(default)]
     capabilities: Vec<String>,
+    #[serde(default)]
+    max_players: u32,
 }
 
 pub fn discover_modules(mut registry: ResMut<ModuleRegistry>) {
@@ -378,6 +380,8 @@ pub fn discover_modules(mut registry: ResMut<ModuleRegistry>) {
             author: Box::leak(manifest.author.into_boxed_str()),
             state,
             capabilities: caps,
+            max_players: manifest.max_players,
+            icon: Handle::default(),
         });
     }
 }

--- a/client/crates/minigames/duck_hunt/Cargo.toml
+++ b/client/crates/minigames/duck_hunt/Cargo.toml
@@ -6,3 +6,4 @@ edition = "2021"
 [dependencies]
 bevy = "0.12"
 platform-api = { path = "../../../../crates/platform-api" }
+anyhow = "1"

--- a/client/crates/minigames/duck_hunt/src/lib.rs
+++ b/client/crates/minigames/duck_hunt/src/lib.rs
@@ -1,3 +1,4 @@
+use anyhow::Result;
 use bevy::prelude::*;
 use platform_api::{AppState, CapabilityFlags, GameModule, ModuleContext, ModuleMetadata, ServerApp};
 
@@ -52,17 +53,21 @@ impl GameModule for DuckHuntPlugin {
             author: "Unknown",
             state: AppState::DuckHunt,
             capabilities: CapabilityFlags::LOBBY_PAD,
+            max_players: 4,
+            icon: Handle::default(),
         }
     }
 
     fn register(_app: &mut App) {}
 
-    fn enter(ctx: &mut ModuleContext) {
+    fn enter(ctx: &mut ModuleContext) -> Result<()> {
         setup(ctx.world());
+        Ok(())
     }
 
-    fn exit(ctx: &mut ModuleContext) {
+    fn exit(ctx: &mut ModuleContext) -> Result<()> {
         cleanup(ctx.world());
+        Ok(())
     }
 
     fn server_register(_app: &mut ServerApp) {}

--- a/crates/platform-api/Cargo.toml
+++ b/crates/platform-api/Cargo.toml
@@ -6,3 +6,4 @@ edition = "2024"
 [dependencies]
 bevy = { version = "0.12", default-features = false, features = ["bevy_winit", "bevy_render", "bevy_core_pipeline", "bevy_pbr", "bevy_ui", "bevy_text", "bevy_audio", "x11"] }
 bitflags = "2"
+anyhow = "1"

--- a/crates/platform-api/src/lib.rs
+++ b/crates/platform-api/src/lib.rs
@@ -1,6 +1,7 @@
 use bevy::ecs::world::Mut;
 use bevy::prelude::*;
 use bitflags::bitflags;
+use anyhow::Result;
 
 #[derive(States, Default, Clone, Eq, PartialEq, Hash, Debug)]
 pub enum AppState {
@@ -36,6 +37,10 @@ pub struct ModuleMetadata {
     pub state: AppState,
     /// Feature flags implemented by the module.
     pub capabilities: CapabilityFlags,
+    /// Maximum number of players supported.
+    pub max_players: u32,
+    /// Icon representing the module.
+    pub icon: Handle<Image>,
 }
 
 /// Context handed to module hooks giving access to the Bevy [`World`] and other
@@ -99,8 +104,8 @@ pub trait GameModule: Plugin + Sized {
     fn server_register(_app: &mut ServerApp) {}
 
     /// Called whenever the engine transitions into the module's state.
-    fn enter(_context: &mut ModuleContext) {}
+    fn enter(_context: &mut ModuleContext) -> Result<()> { Ok(()) }
 
     /// Called whenever the engine leaves the module's state.
-    fn exit(_context: &mut ModuleContext) {}
+    fn exit(_context: &mut ModuleContext) -> Result<()> { Ok(()) }
 }


### PR DESCRIPTION
## Summary
- track max players and icon in module metadata
- allow module enter/exit to fail with anyhow::Result
- update Duck Hunt module and engine loader for new metadata fields

## Testing
- `cargo check`
- `npm run prettier`


------
https://chatgpt.com/codex/tasks/task_e_68bc553faaf8832389b46c091e45ccaf