### PR TITLE
Register server modules from server crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5915,8 +5915,11 @@ name = "server"
 version = "0.1.0"
 dependencies = [
  "axum",
+ "bevy 0.12.1",
+ "duck_hunt",
  "lettre",
  "once_cell",
+ "platform-api",
  "sqlx",
  "tokio",
  "tower-http",

--- a/client/crates/engine/src/lib.rs
+++ b/client/crates/engine/src/lib.rs
@@ -24,12 +24,7 @@ impl Plugin for EnginePlugin {
             .add_systems(OnExit(AppState::Lobby), cleanup_lobby)
             .add_systems(
                 Update,
-                (
-                    lobby_keyboard,
-                    player_move,
-                    player_look,
-                    pad_trigger,
-                )
+                (lobby_keyboard, player_move, player_look, pad_trigger)
                     .run_if(in_state(AppState::Lobby)),
             )
             .add_systems(Update, exit_to_lobby);
@@ -74,7 +69,10 @@ pub fn setup_lobby(
             RigidBody::KinematicPositionBased,
             Collider::capsule_y(0.5, 0.3),
             KinematicCharacterController::default(),
-            Controller { yaw: 0.0, pitch: 0.0 },
+            Controller {
+                yaw: 0.0,
+                pitch: 0.0,
+            },
             Player,
             LobbyEntity,
         ))
@@ -90,7 +88,10 @@ pub fn setup_lobby(
     ));
     commands.spawn((
         PbrBundle {
-            mesh: meshes.add(Mesh::from(shape::Plane { size: 10.0, subdivisions: 0 })),
+            mesh: meshes.add(Mesh::from(shape::Plane {
+                size: 10.0,
+                subdivisions: 0,
+            })),
             material: materials.add(Color::rgb(0.3, 0.5, 0.3).into()),
             ..default()
         },
@@ -242,8 +243,7 @@ fn player_move(
         if keys.pressed(KeyCode::D) {
             direction += transform.right();
         }
-        controller.translation =
-            Some(direction.normalize_or_zero() * 5.0 * time.delta_seconds());
+        controller.translation = Some(direction.normalize_or_zero() * 5.0 * time.delta_seconds());
     }
 }
 
@@ -302,7 +302,6 @@ pub fn register_module<M: GameModule + Default + 'static>(app: &mut App) {
     let info = M::metadata();
     let state = info.state.clone();
     M::register(app);
-    M::server_register(app);
     app.world
         .get_resource_mut::<ModuleRegistry>()
         .expect("EnginePlugin must be added before registering modules")

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -10,3 +10,6 @@ axum = { version = "0.7", features = ["ws"] }
 tower-http = { version = "0.6", features = ["fs", "set-header"] }
 tokio = { version = "1", features = ["macros", "rt-multi-thread", "signal"] }
 sqlx = { version = "0.7", features = ["runtime-tokio-rustls", "postgres", "macros"] }
+platform-api = { path = "../crates/platform-api" }
+duck_hunt = { path = "../client/crates/minigames/duck_hunt" }
+bevy = "0.12"

--- a/server/src/lib.rs
+++ b/server/src/lib.rs
@@ -1,1 +1,33 @@
 pub mod email;
+
+use bevy::prelude::*;
+use platform_api::{GameModule, ModuleContext, ServerApp};
+
+pub fn register_module<M: GameModule + Default + 'static>(app: &mut ServerApp) {
+    let state = M::metadata().state.clone();
+    M::server_register(app);
+    app.add_plugins(M::default());
+    app.add_systems(OnEnter(state.clone()), enter_module::<M>);
+    app.add_systems(OnExit(state), exit_module::<M>);
+}
+
+fn enter_module<M: GameModule>(world: &mut World) {
+    let mut ctx = ModuleContext::new(world);
+    M::enter(&mut ctx).expect("module enter failed");
+}
+
+fn exit_module<M: GameModule>(world: &mut World) {
+    let mut ctx = ModuleContext::new(world);
+    M::exit(&mut ctx).expect("module exit failed");
+}
+
+pub trait ServerAppExt {
+    fn add_game_module<M: GameModule + Default + 'static>(&mut self) -> &mut Self;
+}
+
+impl ServerAppExt for ServerApp {
+    fn add_game_module<M: GameModule + Default + 'static>(&mut self) -> &mut Self {
+        register_module::<M>(self);
+        self
+    }
+}

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -1,16 +1,18 @@
 use std::{net::SocketAddr, sync::Arc};
 
 use axum::{
+    Router,
     extract::{
-        ws::{WebSocket, WebSocketUpgrade},
         State,
+        ws::{WebSocket, WebSocketUpgrade},
     },
-    http::{header::CACHE_CONTROL, HeaderName, HeaderValue, StatusCode},
+    http::{HeaderName, HeaderValue, StatusCode, header::CACHE_CONTROL},
     response::IntoResponse,
     routing::{get, get_service},
-    Router,
 };
-use server::email::EmailService;
+use duck_hunt::DuckHuntPlugin;
+use platform_api::ServerApp;
+use server::{ServerAppExt, email::EmailService};
 use sqlx::PgPool;
 use tower_http::{services::ServeDir, set_header::SetResponseHeaderLayer};
 
@@ -77,6 +79,9 @@ async fn main() {
     ));
 
     let state = Arc::new(AppState { db, email });
+
+    let mut _game_app = ServerApp::new();
+    _game_app.add_game_module::<DuckHuntPlugin>();
 
     let assets_service =
         get_service(ServeDir::new("assets")).layer(SetResponseHeaderLayer::if_not_present(


### PR DESCRIPTION
## Summary
- drop server-side registration from client engine
- add server utilities to register modules and call them on startup
- pull in platform and module dependencies for server crate

## Testing
- `npm run prettier`
- `cargo check`


------
https://chatgpt.com/codex/tasks/task_e_68bc56f74f408323a5b852faefbd14d5