### PR TITLE
docs: expand networking and module guides

### DIFF
--- a/docs/modules.md
+++ b/docs/modules.md
@@ -1,6 +1,7 @@
 # Modules
 
-Arena modules extend the core game with new mechanics, assets, and server logic. Modules are regular Rust crates that plug into the server during startup.
+Arena modules extend the core game with new mechanics, assets, and server logic.
+Modules are regular Rust crates that plug into the server during startup.
 
 ## Setup
 
@@ -8,13 +9,15 @@ Arena modules extend the core game with new mechanics, assets, and server logic.
    ```bash
    cargo new crates/my_module --lib
    ```
-2. Add the crate to the workspace `Cargo.toml` and implement the `Module` trait exported by the core library.
+2. Add the crate to the workspace `Cargo.toml` and implement the `GameModule` trait exported by the core library.
 3. Include any client-side assets in the module and rebuild the workspace with `cargo build`.
-4. Review the [netcode design](netcode.md) to understand how modules communicate with clients.
+4. Create a descriptor at `assets/modules/<id>/module.toml` containing metadata and capability flags for the module.
+5. Review the [netcode design](netcode.md) to understand how modules communicate with clients.
 
 ## Usage
 
 - Register the module with the server by calling its `register()` function from `server/src/main.rs` or the module loader.
+- Set capability flags in `module.toml` to advertise features like networking or UI.
 - Rebuild and restart the server:
   ```bash
   cargo run -p server
@@ -23,7 +26,8 @@ Arena modules extend the core game with new mechanics, assets, and server logic.
 
 ## Reference
 
-- `Module` trait: defines `fn register(&mut World)` and `fn update(&mut World, dt: f32)` hooks.
-- `ServerPlugin`: convenience wrapper for attaching modules at runtime.
+- `GameModule` trait: defines lifecycle hooks for initialization and per-tick updates.
+- `module.toml`: metadata file located at `assets/modules/<id>/module.toml`.
+- Capability flags: `netcode`, `ui`, and other features declared in `module.toml`.
 - Modules may send custom messages through the network layer; see the [netcode guide](netcode.md) for message types.
 - Deployment notes for modules are covered in the [operations guide](ops.md).

--- a/docs/ops.md
+++ b/docs/ops.md
@@ -25,8 +25,11 @@ This guide covers deploying Arena and operating it in production environments.
   ```
 - Serve the `web/` directory with your preferred static file server.
 - Monitor the process and restart on failure using a supervisor such as `systemd` or `pm2`.
-- For multiplayer features ensure the required headers are set; see the [netcode guide](netcode.md).
-- Modules can be added or removed without downtime; refer to the [modules guide](modules.md).
+- For multiplayer features such as WebRTC DataChannels ensure the required
+  headers are set; see the [netcode guide](netcode.md).
+- Modules can be added or removed without downtime; refer to the [modules
+  guide](modules.md) for capability flags and packaging via
+  `assets/modules/<id>/module.toml`.
 
 ## Reference
 


### PR DESCRIPTION
## Summary
- document WebRTC DataChannels, snapshot delta compression, client prediction, and 60 Hz tick
- describe GameModule trait, capability flags, and module packaging
- update ops guide references to new netcode and module docs

## Testing
- `npm run prettier`


------
https://chatgpt.com/codex/tasks/task_e_68bc681a41908323a502598d9b505f6e