### PR TITLE
feat: versioned cache for service worker

### DIFF
--- a/web/sw.js
+++ b/web/sw.js
@@ -1,10 +1,27 @@
+const MANIFEST_VERSION = "__PRECACHE_VERSION__";
+const PRECACHE = `precache-${MANIFEST_VERSION}`;
+
 self.addEventListener("install", (event) => {
   event.waitUntil(
-    caches.open("precache").then(async (cache) => {
+    caches.open(PRECACHE).then(async (cache) => {
       const res = await fetch("/assets/precache.json");
       const files = await res.json();
       return cache.addAll(files);
     }),
+  );
+});
+
+self.addEventListener("activate", (event) => {
+  event.waitUntil(
+    caches.keys().then((keys) =>
+      Promise.all(
+        keys.map((key) => {
+          if (key !== PRECACHE) {
+            return caches.delete(key);
+          }
+        }),
+      ),
+    ),
   );
 });
 


### PR DESCRIPTION
## Summary
- include manifest-based version in service worker cache names
- remove stale caches on activate and network fallback
- generate manifest version in xtask and inject into sw.js

## Testing
- `npm run prettier`
- `cargo test -p xtask`


------
https://chatgpt.com/codex/tasks/task_e_68bc698358288323bffbb454628b3c8a