### PR TITLE
Use owned Strings for module metadata

### DIFF
--- a/client/crates/engine/src/lib.rs
+++ b/client/crates/engine/src/lib.rs
@@ -373,10 +373,10 @@ pub fn discover_modules(mut registry: ResMut<ModuleRegistry>) {
             }
         }
         registry.modules.push(ModuleMetadata {
-            id: Box::leak(manifest.id.into_boxed_str()),
-            name: Box::leak(manifest.name.into_boxed_str()),
-            version: Box::leak(manifest.version.into_boxed_str()),
-            author: Box::leak(manifest.author.into_boxed_str()),
+            id: manifest.id,
+            name: manifest.name,
+            version: manifest.version,
+            author: manifest.author,
             state,
             capabilities: caps,
             max_players: manifest.max_players,

--- a/client/crates/minigames/duck_hunt/src/lib.rs
+++ b/client/crates/minigames/duck_hunt/src/lib.rs
@@ -1,6 +1,8 @@
 use anyhow::Result;
 use bevy::prelude::*;
-use platform_api::{AppState, CapabilityFlags, GameModule, ModuleContext, ModuleMetadata, ServerApp};
+use platform_api::{
+    AppState, CapabilityFlags, GameModule, ModuleContext, ModuleMetadata, ServerApp,
+};
 
 #[derive(Default)]
 pub struct DuckHuntPlugin;
@@ -47,10 +49,10 @@ impl GameModule for DuckHuntPlugin {
 
     fn metadata() -> ModuleMetadata {
         ModuleMetadata {
-            id: Self::ID,
-            name: "Duck Hunt",
-            version: "0.1.0",
-            author: "Unknown",
+            id: Self::ID.to_string(),
+            name: "Duck Hunt".to_string(),
+            version: "0.1.0".to_string(),
+            author: "Unknown".to_string(),
             state: AppState::DuckHunt,
             capabilities: CapabilityFlags::LOBBY_PAD,
             max_players: 4,

--- a/crates/platform-api/src/lib.rs
+++ b/crates/platform-api/src/lib.rs
@@ -1,7 +1,7 @@
+use anyhow::Result;
 use bevy::ecs::world::Mut;
 use bevy::prelude::*;
 use bitflags::bitflags;
-use anyhow::Result;
 
 #[derive(States, Default, Clone, Eq, PartialEq, Hash, Debug)]
 pub enum AppState {
@@ -26,13 +26,13 @@ bitflags! {
 #[derive(Clone)]
 pub struct ModuleMetadata {
     /// Unique string identifier for the module.
-    pub id: &'static str,
+    pub id: String,
     /// Human-readable name shown to players.
-    pub name: &'static str,
+    pub name: String,
     /// Semver-style version string.
-    pub version: &'static str,
+    pub version: String,
     /// Name of the author or organization.
-    pub author: &'static str,
+    pub author: String,
     /// The [`AppState`] associated with the module.
     pub state: AppState,
     /// Feature flags implemented by the module.
@@ -104,8 +104,12 @@ pub trait GameModule: Plugin + Sized {
     fn server_register(_app: &mut ServerApp) {}
 
     /// Called whenever the engine transitions into the module's state.
-    fn enter(_context: &mut ModuleContext) -> Result<()> { Ok(()) }
+    fn enter(_context: &mut ModuleContext) -> Result<()> {
+        Ok(())
+    }
 
     /// Called whenever the engine leaves the module's state.
-    fn exit(_context: &mut ModuleContext) -> Result<()> { Ok(()) }
+    fn exit(_context: &mut ModuleContext) -> Result<()> {
+        Ok(())
+    }
 }


### PR DESCRIPTION
## Summary
- store module metadata fields as owned `String`
- remove `Box::leak` conversions in engine module discovery
- adjust Duck Hunt module to construct `ModuleMetadata` with `String`

## Testing
- `npm run prettier`
- `cargo test` *(fails: email::tests::rate_limiting, email::tests::invalid_address)*

------
https://chatgpt.com/codex/tasks/task_e_68bc6ce5f0748323af1289fdf8345278