### PR TITLE
Rename capability flag constants to uppercase

### DIFF
--- a/client/crates/engine/src/lib.rs
+++ b/client/crates/engine/src/lib.rs
@@ -364,11 +364,11 @@ pub fn discover_modules(mut registry: ResMut<ModuleRegistry>) {
         for cap in manifest.capabilities {
             match cap.as_str() {
                 "LOBBY_PAD" => caps |= CapabilityFlags::LOBBY_PAD,
-                "NeedsPhysics" => caps |= CapabilityFlags::NeedsPhysics,
-                "UsesHitscan" => caps |= CapabilityFlags::UsesHitscan,
-                "NeedsNav" => caps |= CapabilityFlags::NeedsNav,
-                "UsesVehicles" => caps |= CapabilityFlags::UsesVehicles,
-                "UsesFlight" => caps |= CapabilityFlags::UsesFlight,
+                "NeedsPhysics" => caps |= CapabilityFlags::NEEDS_PHYSICS,
+                "UsesHitscan" => caps |= CapabilityFlags::USES_HITSCAN,
+                "NeedsNav" => caps |= CapabilityFlags::NEEDS_NAV,
+                "UsesVehicles" => caps |= CapabilityFlags::USES_VEHICLES,
+                "UsesFlight" => caps |= CapabilityFlags::USES_FLIGHT,
                 _ => {}
             }
         }

--- a/crates/platform-api/src/lib.rs
+++ b/crates/platform-api/src/lib.rs
@@ -14,11 +14,11 @@ bitflags! {
     #[derive(Default, Debug, Clone, Copy, PartialEq, Eq, Hash)]
     pub struct CapabilityFlags: u32 {
         const LOBBY_PAD = 0b0001;
-        const NeedsPhysics = 0b0010;
-        const UsesHitscan = 0b0100;
-        const NeedsNav = 0b1000;
-        const UsesVehicles = 0b1_0000;
-        const UsesFlight = 0b10_0000;
+        const NEEDS_PHYSICS = 0b0010;
+        const USES_HITSCAN = 0b0100;
+        const NEEDS_NAV = 0b1000;
+        const USES_VEHICLES = 0b1_0000;
+        const USES_FLIGHT = 0b10_0000;
     }
 }
 


### PR DESCRIPTION
## Summary
- rename capability flag constants to upper snake case
- update engine to use new capability flag names

## Testing
- `cargo fmt`
- `npm run prettier`
- `cargo check`


------
https://chatgpt.com/codex/tasks/task_e_68bc6fd41838832394238a4bee80916b