### PR TITLE
docs: add Duck Hunt module guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ cargo run -p xtask
 cargo run -p server
 ```
 
-For details on the networking model see the [Netcode guide](docs/netcode.md). To extend gameplay, follow the [Module guide](docs/modules.md).
+For details on the networking model see the [Netcode guide](docs/netcode.md). To extend gameplay, follow the [Module guide](docs/modules.md) or the example [Duck Hunt module](docs/DuckHunt.md).
 
 ## Running
 
@@ -54,6 +54,7 @@ npm run prettier
 Additional resources:
 
 - [Module development](docs/modules.md)
+- [Duck Hunt module](docs/DuckHunt.md)
 - [Netcode design](docs/netcode.md)
 - [Deployment and operations](docs/ops.md)
 
@@ -64,3 +65,4 @@ Documentation lives under `docs/`:
 - [Netcode](docs/netcode.md)
 - [Operations](docs/ops.md)
 - [Modules](docs/modules.md)
+- [Duck Hunt](docs/DuckHunt.md)

--- a/docs/DuckHunt.md
+++ b/docs/DuckHunt.md
@@ -1,0 +1,29 @@
+# Duck Hunt Module
+
+A sample module that recreates the classic light-gun game in Arena.
+
+## Gameplay
+
+Players shoot ducks as they fly across the screen. Each round spawns a wave of
+ducks with increasing speed and erratic flight patterns. Missing too many
+shots ends the round.
+
+## Controls
+
+- **Mouse click** or **Spacebar**: fire the shotgun
+- **Arrow keys**: move the crosshair
+- **R**: reload when out of shells
+
+## Networking
+
+The server spawns and tracks all ducks. Clients send shot events with their
+crosshair position. The server validates hits and broadcasts duck positions
+every tick using the standard snapshot protocol. A custom message ID conveys
+shot events to the server.
+
+## Assets
+
+- Duck sprite sheet with animation frames
+- Background images for sky and ground
+- Sound effects for quacks, shots, and reloading
+- `module.toml` descriptor under `assets/modules/duck_hunt/`

--- a/docs/modules.md
+++ b/docs/modules.md
@@ -31,3 +31,4 @@ Modules are regular Rust crates that plug into the server during startup.
 - Capability flags: `netcode`, `ui`, and other features declared in `module.toml`.
 - Modules may send custom messages through the network layer; see the [netcode guide](netcode.md) for message types.
 - Deployment notes for modules are covered in the [operations guide](ops.md).
+- Example module: [Duck Hunt](DuckHunt.md) demonstrating networking and asset integration.


### PR DESCRIPTION
## Summary
- add Duck Hunt module guide with gameplay, controls, networking, and assets
- link Duck Hunt guide from README and module docs

## Testing
- `npm run prettier docs/DuckHunt.md docs/modules.md README.md`


------
https://chatgpt.com/codex/tasks/task_e_68bc7752f0188323bf92cb23694f7cce