### PR TITLE
Add optional SMTP authentication

### DIFF
--- a/docs/Email.md
+++ b/docs/Email.md
@@ -4,20 +4,22 @@ This guide covers configuration of Arena's outgoing email system.
 
 ## Environment variables and CLI flags
 
-| Env var               | CLI flag          | Description                               | Default           |
-| --------------------- | ----------------- | ----------------------------------------- | ----------------- |
-| `ARENA_SMTP_HOST`     | `--smtp-host`     | SMTP server hostname                      | `localhost`       |
-| `ARENA_SMTP_PORT`     | `--smtp-port`     | SMTP server port                          | `25`              |
-| `ARENA_SMTP_FROM`     | `--smtp-from`     | Sender address for all mail               | `arena@localhost` |
-| `ARENA_SMTP_STARTTLS` | `--smtp-starttls` | STARTTLS mode (`auto`, `always`, `never`) | `auto`            |
-| `ARENA_SMTP_SMTPS`    | `--smtp-smtps`    | Use SMTPS (implicit TLS)                  | `false`           |
-| `ARENA_SMTP_TIMEOUT`  | `--smtp-timeout`  | Connection timeout in milliseconds        | `10000`           |
+| Env var                 | CLI flag            | Description                               | Default           |
+| ----------------------- | ------------------- | ----------------------------------------- | ----------------- |
+| `ARENA_SMTP_HOST`       | `--smtp-host`       | SMTP server hostname                      | `localhost`       |
+| `ARENA_SMTP_PORT`       | `--smtp-port`       | SMTP server port                          | `25`              |
+| `ARENA_SMTP_FROM`       | `--smtp-from`       | Sender address for all mail               | `arena@localhost` |
+| `ARENA_SMTP_STARTTLS`   | `--smtp-starttls`   | STARTTLS mode (`auto`, `always`, `never`) | `auto`            |
+| `ARENA_SMTP_SMTPS`      | `--smtp-smtps`      | Use SMTPS (implicit TLS)                  | `false`           |
+| `ARENA_SMTP_USER`       | `--smtp-user`       | SMTP username                             | -                 |
+| `ARENA_SMTP_PASS`       | `--smtp-pass`       | SMTP password                             | -                 |
+| `ARENA_SMTP_TIMEOUT_MS` | `--smtp-timeout-ms` | Connection timeout in milliseconds        | `10000`           |
 
 ## Authentication
 
-Arena currently does not implement SMTP authentication. If your mail
-provider requires credentials, run Arena behind a local relay (such as
-Postfix or Exim) that handles authentication to the upstream server.
+Set `ARENA_SMTP_USER`/`--smtp-user` and `ARENA_SMTP_PASS`/`--smtp-pass`
+to authenticate with your SMTP provider. If omitted, no authentication
+is performed.
 
 ## STARTTLS and SMTPS
 
@@ -49,7 +51,8 @@ export ARENA_SMTP_HOST=smtp.example.com
 export ARENA_SMTP_PORT=587
 export ARENA_SMTP_FROM=arena@example.com
 export ARENA_SMTP_STARTTLS=always
-
+export ARENA_SMTP_USER=mailuser
+export ARENA_SMTP_PASS=secret
 cargo run -p server
 ```
 
@@ -59,7 +62,7 @@ cargo run -p server
   and that the server allows connections from your host.
 - **TLS handshake failures** – ensure STARTTLS/SMTPS settings match the
   server's requirements and that system CA certificates are up to date.
-- **Authentication required** – configure a local relay capable of
-  authenticating to the upstream SMTP provider.
+- **Authentication required** – ensure `ARENA_SMTP_USER` and
+  `ARENA_SMTP_PASS` are set correctly.
 - **Persistent failures** – check server logs for retry warnings and use
   `/admin/mail/test` to verify connectivity.

--- a/server/src/email.rs
+++ b/server/src/email.rs
@@ -1,4 +1,5 @@
 use lettre::address::AddressError;
+use lettre::transport::smtp::authentication::Credentials;
 use lettre::transport::smtp::client::{Tls, TlsParameters};
 use lettre::{Message, SmtpTransport, Transport};
 use once_cell::sync::Lazy;
@@ -43,6 +44,8 @@ pub struct SmtpConfig {
     pub starttls: StartTls,
     pub smtps: bool,
     pub timeout: u64,
+    pub user: Option<String>,
+    pub pass: Option<String>,
 }
 
 impl Default for SmtpConfig {
@@ -54,6 +57,8 @@ impl Default for SmtpConfig {
             starttls: StartTls::Auto,
             smtps: false,
             timeout: 10000,
+            user: None,
+            pass: None,
         }
     }
 }
@@ -118,6 +123,10 @@ impl EmailService {
                 StartTls::Never => builder.tls(Tls::None),
             }
         };
+
+        if let (Some(user), Some(pass)) = (config.user.as_ref(), config.pass.as_ref()) {
+            builder = builder.credentials(Credentials::new(user.clone(), pass.clone()));
+        }
 
         let transport = builder.build();
         Self::new_with_transport(config.from, transport)

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -36,8 +36,12 @@ struct Cli {
     smtp_starttls: String,
     #[arg(long, env = "ARENA_SMTP_SMTPS", default_value_t = false)]
     smtp_smtps: bool,
-    #[arg(long, env = "ARENA_SMTP_TIMEOUT", default_value_t = 10000)]
-    smtp_timeout: u64,
+    #[arg(long, env = "ARENA_SMTP_USER")]
+    smtp_user: Option<String>,
+    #[arg(long, env = "ARENA_SMTP_PASS")]
+    smtp_pass: Option<String>,
+    #[arg(long, env = "ARENA_SMTP_TIMEOUT_MS", default_value_t = 10000)]
+    smtp_timeout_ms: u64,
 }
 
 impl Cli {
@@ -48,7 +52,9 @@ impl Cli {
             from: self.smtp_from.clone(),
             starttls: self.smtp_starttls.parse().unwrap_or_default(),
             smtps: self.smtp_smtps,
-            timeout: self.smtp_timeout,
+            timeout: self.smtp_timeout_ms,
+            user: self.smtp_user.clone(),
+            pass: self.smtp_pass.clone(),
         }
     }
 }


### PR DESCRIPTION
## Summary
- support SMTP user/password credentials and timeout flag
- wire new options through CLI and email service
- document SMTP auth and updated flags

## Testing
- `npm run prettier`
- `cargo test -p server -- --test-threads=1`


------
https://chatgpt.com/codex/tasks/task_e_68bc8a04ed288323acbbc17c47950e1b