### PR TITLE
Document SMTP authentication and timeout override

### DIFF
--- a/docs/Email.md
+++ b/docs/Email.md
@@ -17,9 +17,10 @@ This guide covers configuration of Arena's outgoing email system.
 
 ## Authentication
 
-Set `ARENA_SMTP_USER`/`--smtp-user` and `ARENA_SMTP_PASS`/`--smtp-pass`
-to authenticate with your SMTP provider. If omitted, no authentication
-is performed.
+Arena supports basic username/password authentication. Provide
+`ARENA_SMTP_USER`/`--smtp-user` and `ARENA_SMTP_PASS`/`--smtp-pass` to
+authenticate with your SMTP provider. If these are not set, Arena
+connects without authentication.
 
 ## STARTTLS and SMTPS
 
@@ -53,6 +54,7 @@ export ARENA_SMTP_FROM=arena@example.com
 export ARENA_SMTP_STARTTLS=always
 export ARENA_SMTP_USER=mailuser
 export ARENA_SMTP_PASS=secret
+export ARENA_SMTP_TIMEOUT_MS=20000
 cargo run -p server
 ```
 


### PR DESCRIPTION
## Summary
- clarify SMTP authentication using ARENA_SMTP_USER and ARENA_SMTP_PASS
- mention ARENA_SMTP_TIMEOUT_MS/--smtp-timeout-ms in docs and example
- show sample configuration with credentials and timeout override

## Testing
- `npm run prettier`
- `cargo test` *(fails: The system library `alsa` required by crate `alsa-sys` was not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bc9237f8308323b0edd0c329e39a65