### PR TITLE
server: use 60 Hz interval for room tick

### DIFF
--- a/server/src/room.rs
+++ b/server/src/room.rs
@@ -70,7 +70,7 @@ impl RoomManager {
         let room = Arc::new(Mutex::new(Room::new()));
         let tick_room = Arc::clone(&room);
         tokio::spawn(async move {
-            let mut interval = time::interval(Duration::from_millis(16));
+            let mut interval = time::interval(Duration::from_secs_f64(1.0 / 60.0));
             loop {
                 interval.tick().await;
                 tick_room.lock().await.tick().await;


### PR DESCRIPTION
## Summary
- express room tick interval with a 60 Hz `Duration::from_secs_f64`

## Testing
- `npm run prettier`
- `cargo test -p server` *(fails: email::tests::lock_poisoned)*

------
https://chatgpt.com/codex/tasks/task_e_68bc9798e348832396bfce4db5647b5f