### PR TITLE
Use tokio-based async email sending

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3436,11 +3436,13 @@ version = "0.11.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5cb54db6ff7a89efac87dba5baeac57bb9ccd726b49a9b6f21fb92b3966aaf56"
 dependencies = [
+ "async-trait",
  "base64 0.22.1",
  "chumsky",
  "email-encoding",
  "email_address",
  "fastrand 2.3.0",
+ "futures-io",
  "futures-util",
  "hostname",
  "httpdate",
@@ -3452,6 +3454,7 @@ dependencies = [
  "quoted_printable",
  "socket2 0.6.0",
  "tokio",
+ "tokio-native-tls",
  "url",
 ]
 
@@ -5889,6 +5892,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.106",
+]
+
+[[package]]
+name = "tokio-native-tls"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
+dependencies = [
+ "native-tls",
+ "tokio",
 ]
 
 [[package]]

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
-lettre = { version = "0.11", features = ["builder", "smtp-transport"] }
+lettre = { version = "0.11", features = ["builder", "smtp-transport", "tokio1", "tokio1-native-tls"] }
 once_cell = "1.18"
 axum = { version = "0.7", features = ["ws"] }
 tower-http = { version = "0.6", features = ["fs", "set-header"] }


### PR DESCRIPTION
## Summary
- switch email transport to `AsyncSmtpTransport<Tokio1Executor>`
- send queued mail with `tokio::spawn` and async retry logic
- enable tokio runtime features for lettre

## Testing
- `cargo test -p server`


------
https://chatgpt.com/codex/tasks/task_e_68bca282cff88323a5562c8c9ee3464f