### PR TITLE
Use WebSocket for WebRTC signaling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -524,7 +524,7 @@ dependencies = [
  "sha1",
  "sync_wrapper",
  "tokio",
- "tokio-tungstenite",
+ "tokio-tungstenite 0.24.0",
  "tower",
  "tower-layer",
  "tower-service",
@@ -3848,10 +3848,14 @@ dependencies = [
  "async-trait",
  "bevy",
  "bytes",
+ "futures-channel",
+ "js-sys",
  "postcard",
  "serde",
  "tokio",
+ "wasm-bindgen",
  "wasm-bindgen-futures",
+ "web-sys",
  "webrtc",
 ]
 
@@ -5175,6 +5179,7 @@ dependencies = [
  "clap",
  "duck_hunt_server",
  "env_logger",
+ "futures-util",
  "glam",
  "lettre",
  "log",
@@ -5184,6 +5189,7 @@ dependencies = [
  "serde",
  "sqlx",
  "tokio",
+ "tokio-tungstenite 0.21.0",
  "tower-http",
  "webrtc",
 ]
@@ -5923,6 +5929,18 @@ dependencies = [
 
 [[package]]
 name = "tokio-tungstenite"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c83b561d025642014097b66e6c1bb422783339e0909e4429cde4749d1990bc38"
+dependencies = [
+ "futures-util",
+ "log",
+ "tokio",
+ "tungstenite 0.21.0",
+]
+
+[[package]]
+name = "tokio-tungstenite"
 version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "edc5f74e248dc973e0dbb7b74c7e0d6fcc301c694ff50049504004ef4d0cdcd9"
@@ -5930,7 +5948,7 @@ dependencies = [
  "futures-util",
  "log",
  "tokio",
- "tungstenite",
+ "tungstenite 0.24.0",
 ]
 
 [[package]]
@@ -6152,6 +6170,25 @@ name = "ttf-parser"
 version = "0.25.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2df906b07856748fa3f6e0ad0cbaa047052d4a7dd609e231c4f72cee8c36f31"
+
+[[package]]
+name = "tungstenite"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ef1a641ea34f399a848dea702823bbecfb4c486f911735368f1f137cb8257e1"
+dependencies = [
+ "byteorder",
+ "bytes",
+ "data-encoding",
+ "http",
+ "httparse",
+ "log",
+ "rand",
+ "sha1",
+ "thiserror 1.0.69",
+ "url",
+ "utf-8",
+]
 
 [[package]]
 name = "tungstenite"

--- a/crates/net/Cargo.toml
+++ b/crates/net/Cargo.toml
@@ -17,3 +17,9 @@ tokio = { version = "1", features = ["rt-multi-thread", "macros"], optional = tr
 webrtc = { version = "0.11", optional = true }
 bytes = "1"
 wasm-bindgen-futures = "0.4"
+
+[target."cfg(target_arch = \"wasm32\")".dependencies]
+futures-channel = "0.3"
+wasm-bindgen = "0.2"
+web-sys = { version = "0.3", features = ["BinaryType", "MessageEvent", "WebSocket"] }
+js-sys = "0.3"

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -20,3 +20,7 @@ clap = { version = "4", features = ["derive", "env"] }
 duck_hunt_server = { path = "../crates/minigames/duck_hunt" }
 glam = "0.24"
 postcard = { version = "1", features = ["alloc"] }
+
+[dev-dependencies]
+tokio-tungstenite = "0.21"
+futures-util = "0.3"


### PR DESCRIPTION
## Summary
- switch server signaling from HTTP POST to WebSocket
- add client WebSocket signaling helper
- test WebRTC handshake over the new route

## Testing
- `npm run prettier`
- `cargo test -p server`


------
https://chatgpt.com/codex/tasks/task_e_68bcaeab89d48323bd444f967624d666