### PR TITLE
feat(web): add canvas and startup hooks

### DIFF
--- a/web/bootstrap.js
+++ b/web/bootstrap.js
@@ -1,7 +1,8 @@
 async function init() {
+  const canvasId = window.BEVY_CANVAS_ID || "bevy-canvas";
   const wasm = await import("./pkg/client.js");
   if (wasm && wasm.default) {
-    await wasm.default();
+    await wasm.default(canvasId);
   }
 }
 

--- a/web/index.html
+++ b/web/index.html
@@ -5,8 +5,23 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link rel="manifest" href="/manifest.json" />
     <title>Arena</title>
+    <style>
+      html,
+      body {
+        width: 100%;
+        height: 100%;
+        margin: 0;
+      }
+      #bevy-canvas {
+        width: 100vw;
+        height: 100vh;
+        display: block;
+      }
+    </style>
   </head>
   <body>
+    <canvas id="bevy-canvas"></canvas>
+    <script src="/startup.js"></script>
     <script type="module" src="/bootstrap.js"></script>
     <script>
       if ("serviceWorker" in navigator) {

--- a/web/startup.js
+++ b/web/startup.js
@@ -1,0 +1,15 @@
+const canvasId = "bevy-canvas";
+window.BEVY_CANVAS_ID = canvasId;
+
+const canvas = document.getElementById(canvasId);
+
+function handleInteraction() {
+  canvas.requestPointerLock();
+  const ctx = window.__bevy_audio_context || window.__bevyAudioContext;
+  if (ctx && ctx.state === "suspended") {
+    ctx.resume();
+  }
+}
+
+window.addEventListener("mousedown", handleInteraction, { once: true });
+window.addEventListener("keydown", handleInteraction, { once: true });


### PR DESCRIPTION
## Summary
- add full-screen `bevy-canvas` element and startup script
- forward canvas id to wasm bootstrap

## Testing
- `npm run prettier`
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68bcb33607788323a30b348f66445d51