### PR TITLE
Handle missing window safely

### DIFF
--- a/client/crates/engine/src/lib.rs
+++ b/client/crates/engine/src/lib.rs
@@ -83,9 +83,13 @@ pub fn setup_lobby(
     asset_server: Option<Res<AssetServer>>,
     mut windows: Query<&mut Window>,
 ) {
-    let mut window = windows.single_mut();
-    window.cursor.grab_mode = CursorGrabMode::Locked;
-    window.cursor.visible = false;
+    if let Ok(mut window) = windows.get_single_mut() {
+        window.cursor.grab_mode = CursorGrabMode::Locked;
+        window.cursor.visible = false;
+    } else {
+        warn!("no window available");
+        return;
+    }
 
     commands
         .spawn((
@@ -235,16 +239,20 @@ fn exit_to_lobby(
     mut windows: Query<&mut Window>,
 ) {
     if keys.just_pressed(KeyCode::Escape) {
-        let mut window = windows.single_mut();
-        let locked = window.cursor.grab_mode == CursorGrabMode::Locked;
-        if locked {
-            window.cursor.grab_mode = CursorGrabMode::None;
-            window.cursor.visible = true;
+        if let Ok(mut window) = windows.get_single_mut() {
+            let locked = window.cursor.grab_mode == CursorGrabMode::Locked;
+            if locked {
+                window.cursor.grab_mode = CursorGrabMode::None;
+                window.cursor.visible = true;
+            } else {
+                window.cursor.grab_mode = CursorGrabMode::Locked;
+                window.cursor.visible = false;
+            }
+            next_state.set(AppState::Lobby);
         } else {
-            window.cursor.grab_mode = CursorGrabMode::Locked;
-            window.cursor.visible = false;
+            warn!("no window available");
+            return;
         }
-        next_state.set(AppState::Lobby);
     }
 }
 

--- a/client/crates/engine/tests/lobby.rs
+++ b/client/crates/engine/tests/lobby.rs
@@ -14,6 +14,15 @@ fn test_app() -> App {
     app
 }
 
+fn app_without_window() -> App {
+    let mut app = App::new();
+    app.add_plugins(MinimalPlugins);
+    app.init_resource::<ModuleRegistry>();
+    app.init_resource::<Assets<Mesh>>();
+    app.init_resource::<Assets<StandardMaterial>>();
+    app
+}
+
 #[test]
 fn spawns_pads_for_modules() {
     let manifest_dir = Path::new(env!("CARGO_MANIFEST_DIR")).join("../../../assets/modules/test_mod");
@@ -65,4 +74,13 @@ fn shows_empty_state_when_registry_empty() {
     }
     assert!(found_msg, "missing empty-state message");
     assert!(found_link, "missing docs link");
+}
+
+#[test]
+fn setup_lobby_handles_missing_window() {
+    let mut app = app_without_window();
+    app.world.run_system_once(setup_lobby);
+
+    // no entities should be spawned without a window
+    assert_eq!(app.world.iter_entities().count(), 0);
 }


### PR DESCRIPTION
## Summary
- avoid panics by safely accessing the single window and warning when absent
- add tests for setup_lobby with no available window

## Testing
- `npm run prettier`
- `cargo test -p engine`


------
https://chatgpt.com/codex/tasks/task_e_68bcb6403bfc8323b08aa1cdfc62dc9f