### PR TITLE
Add null module template and packaging for module assets

### DIFF
--- a/assets/modules/null_module/module.toml
+++ b/assets/modules/null_module/module.toml
@@ -1,0 +1,6 @@
+id = "null_module"
+name = "Null Module"
+version = "1.0.0"
+author = "Template"
+state = "NullModule"
+capabilities = ["LOBBY_PAD"]

--- a/docs/modules.md
+++ b/docs/modules.md
@@ -5,14 +5,16 @@ Modules are regular Rust crates that plug into the server during startup.
 
 ## Setup
 
-1. Create a new crate under `crates/`:
+1. Start by copying the template module located at `assets/modules/null_module`.
+   This provides a minimal `module.toml` descriptor with the `LOBBY_PAD` capability.
+2. Create a new crate under `crates/`:
    ```bash
    cargo new crates/my_module --lib
    ```
-2. Add the crate to the workspace `Cargo.toml` and implement the `GameModule` trait exported by the core library.
-3. Include any client-side assets in the module and rebuild the workspace with `cargo build`.
-4. Create a descriptor at `assets/modules/<id>/module.toml` containing metadata and capability flags for the module.
-5. Review the [netcode design](netcode.md) to understand how modules communicate with clients.
+3. Add the crate to the workspace `Cargo.toml` and implement the `GameModule` trait exported by the core library.
+4. Include any client-side assets in the module and rebuild the workspace with `cargo build`.
+5. Create a descriptor at `assets/modules/<id>/module.toml` containing metadata and capability flags for the module.
+6. Review the [netcode design](netcode.md) to understand how modules communicate with clients.
 
 ## Usage
 
@@ -31,4 +33,5 @@ Modules are regular Rust crates that plug into the server during startup.
 - Capability flags: `netcode`, `ui`, and other features declared in `module.toml`.
 - Modules may send custom messages through the network layer; see the [netcode guide](netcode.md) for message types.
 - Deployment notes for modules are covered in the [operations guide](ops.md).
+- Template module: `null_module` serves as a starting point for new modules.
 - Example module: [Duck Hunt](DuckHunt.md) demonstrating networking and asset integration.


### PR DESCRIPTION
## Summary
- add template `null_module` descriptor
- copy module assets during `xtask` packaging
- document `null_module` usage in module guide

## Testing
- `npm run prettier`
- `cargo check -p xtask`


------
https://chatgpt.com/codex/tasks/task_e_68bcbfc5c4808323b8b9cef30c13ffe5