### PR TITLE
Add minimal null game module

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1657,6 +1657,7 @@ dependencies = [
  "bevy",
  "duck_hunt",
  "engine",
+ "null_module",
 ]
 
 [[package]]
@@ -3925,6 +3926,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4a28e057d01f97e61255210fcff094d74ed0466038633e95017f5beb68e4399"
 dependencies = [
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "null_module"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "bevy",
+ "platform-api",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,4 +7,5 @@ members = [
     "crates/platform-api",
     "xtask",
     "crates/minigames/duck_hunt",
+    "crates/minigames/null_module",
 ]

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -8,3 +8,4 @@ edition = "2024"
 bevy = "0.12"
 engine = { path = "crates/engine" }
 duck_hunt = { path = "crates/minigames/duck_hunt" }
+null_module = { path = "../crates/minigames/null_module" }

--- a/client/src/main.rs
+++ b/client/src/main.rs
@@ -1,11 +1,13 @@
 use bevy::prelude::*;
 use duck_hunt::DuckHuntPlugin;
 use engine::{AppExt, EnginePlugin};
+use null_module::NullModule;
 
 fn main() {
     App::new()
         .add_plugins(DefaultPlugins)
         .add_plugins(EnginePlugin)
         .add_game_module::<DuckHuntPlugin>()
+        .add_game_module::<NullModule>()
         .run();
 }

--- a/crates/minigames/null_module/Cargo.toml
+++ b/crates/minigames/null_module/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "null_module"
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]
+bevy = "0.12"
+platform-api = { path = "../../platform-api" }
+anyhow = "1"

--- a/crates/minigames/null_module/src/lib.rs
+++ b/crates/minigames/null_module/src/lib.rs
@@ -1,0 +1,41 @@
+use anyhow::Result;
+use bevy::prelude::*;
+use platform_api::{
+    AppState, CapabilityFlags, GameModule, ModuleContext, ModuleMetadata, ServerApp,
+};
+
+#[derive(Default)]
+pub struct NullModule;
+
+impl Plugin for NullModule {
+    fn build(&self, _app: &mut App) {}
+}
+
+impl GameModule for NullModule {
+    const ID: &'static str = "null_module";
+
+    fn metadata() -> ModuleMetadata {
+        ModuleMetadata {
+            id: Self::ID.to_string(),
+            name: "Null Module".to_string(),
+            version: "0.1.0".to_string(),
+            author: "Unknown".to_string(),
+            state: AppState::Lobby,
+            capabilities: CapabilityFlags::empty(),
+            max_players: 1,
+            icon: Handle::default(),
+        }
+    }
+
+    fn register(_app: &mut App) {}
+
+    fn enter(_ctx: &mut ModuleContext) -> Result<()> {
+        Ok(())
+    }
+
+    fn exit(_ctx: &mut ModuleContext) -> Result<()> {
+        Ok(())
+    }
+
+    fn server_register(_app: &mut ServerApp) {}
+}

--- a/docs/modules.md
+++ b/docs/modules.md
@@ -24,6 +24,22 @@ Modules are regular Rust crates that plug into the server during startup.
   ```
 - Clients automatically discover the module when they connect.
 
+### Example: Null Module
+
+The `NullModule` demonstrates the minimal structure of a module. It provides empty
+hooks and can be registered on the client:
+
+```rust
+use null_module::NullModule;
+use engine::{AppExt, EnginePlugin};
+
+App::new()
+    .add_plugins(DefaultPlugins)
+    .add_plugins(EnginePlugin)
+    .add_game_module::<NullModule>()
+    .run();
+```
+
 ## Reference
 
 - `GameModule` trait: defines lifecycle hooks for initialization and per-tick updates.


### PR DESCRIPTION
## Summary
- add `NullModule` implementing the `GameModule` trait with no-op hooks
- register `NullModule` in the client alongside existing Duck Hunt module
- document how to register the module via `add_game_module`

## Testing
- `npm run prettier`
- `cargo test` *(fails: linking with `cc` failed: exit status: 1)*

------
https://chatgpt.com/codex/tasks/task_e_68bcbfbd5f1883239b02dd5d121720cf