### PR TITLE
feat(engine): hotload modules and refresh lobby pads

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2238,10 +2238,13 @@ dependencies = [
  "bevy",
  "bevy_rapier3d",
  "futures-lite 2.6.1",
+ "gloo-timers",
+ "notify",
  "platform-api",
  "serde",
  "serde_json",
  "toml",
+ "wasm-bindgen-futures",
 ]
 
 [[package]]
@@ -2380,6 +2383,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
 
 [[package]]
+name = "filetime"
+version = "0.2.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc0505cd1b6fa6580283f6bdf70a73fcf4aba1184038c90902b92b3dd0df63ed"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "libredox",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
 name = "find-msvc-tools"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2473,6 +2488,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
+]
+
+[[package]]
+name = "fsevent-sys"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76ee7a02da4d231650c7cea31349b889be2f45ddb3ef3032d2ec8185f6313fd2"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -2669,7 +2693,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "732dadc05170599ddec9a89653f10d7a2af54da9181b3fa6e2bd49907ec8f7e4"
 dependencies = [
  "core-foundation",
- "inotify",
+ "inotify 0.10.2",
  "io-kit-sys",
  "js-sys",
  "libc",
@@ -2704,6 +2728,18 @@ name = "glob"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
+
+[[package]]
+name = "gloo-timers"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b995a66bb87bebce9a0f4a95aed01daca4872c050bfcb21653361c03bc35e5c"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "js-sys",
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "glow"
@@ -3230,6 +3266,17 @@ checksum = "a257582fdcde896fd96463bf2d40eefea0580021c0712a0e2b028b60b47a837a"
 
 [[package]]
 name = "inotify"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8069d3ec154eb856955c1c0fbffefbf5f3c40a104ec912d4797314c1801abff"
+dependencies = [
+ "bitflags 1.3.2",
+ "inotify-sys",
+ "libc",
+]
+
+[[package]]
+name = "inotify"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fdd168d97690d0b8c412d6b6c10360277f4d7ee495c5d0d5d5fe0854923255cc"
@@ -3413,6 +3460,26 @@ dependencies = [
  "libc",
  "libloading 0.7.4",
  "pkg-config",
+]
+
+[[package]]
+name = "kqueue"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eac30106d7dce88daf4a3fcb4879ea939476d5074a9b7ddd0fb97fa4bed5596a"
+dependencies = [
+ "kqueue-sys",
+ "libc",
+]
+
+[[package]]
+name = "kqueue-sys"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed9625ffda8729b85e45cf04090035ac368927b8cebc34898e7c120f52e4838b"
+dependencies = [
+ "bitflags 1.3.2",
+ "libc",
 ]
 
 [[package]]
@@ -3908,6 +3975,25 @@ name = "nonmax"
 version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "610a5acd306ec67f907abe5567859a3c693fb9886eb1f012ab8f2a47bef3db51"
+
+[[package]]
+name = "notify"
+version = "6.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6205bd8bb1e454ad2e27422015fb5e4f2bcc7e08fa8f27058670d208324a4d2d"
+dependencies = [
+ "bitflags 2.9.4",
+ "crossbeam-channel",
+ "filetime",
+ "fsevent-sys",
+ "inotify 0.9.6",
+ "kqueue",
+ "libc",
+ "log",
+ "mio 0.8.11",
+ "walkdir",
+ "windows-sys 0.48.0",
+]
 
 [[package]]
 name = "ntapi"

--- a/client/crates/engine/Cargo.toml
+++ b/client/crates/engine/Cargo.toml
@@ -12,6 +12,13 @@ toml = "0.8"
 serde_json = "1.0"
 futures-lite = "2.3"
 
+[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+notify = "6"
+
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+wasm-bindgen-futures = "0.4"
+gloo-timers = { version = "0.2", features = ["futures"] }
+
 [features]
 default = ["vehicle", "flight"]
 vehicle = []

--- a/client/crates/engine/tests/hotload.rs
+++ b/client/crates/engine/tests/hotload.rs
@@ -1,0 +1,96 @@
+use bevy::ecs::system::RunSystemOnce;
+use bevy::prelude::*;
+use engine::{
+    discover_modules,
+    hotload_modules,
+    setup_lobby,
+    update_lobby_pads,
+    LobbyPad,
+    ModuleRegistry,
+};
+use platform_api::AppState;
+use std::fs;
+use std::path::Path;
+
+fn test_app() -> App {
+    let mut app = App::new();
+    app.add_plugins(MinimalPlugins);
+    app.add_state::<AppState>();
+    app.init_resource::<ModuleRegistry>();
+    app.init_resource::<Assets<Mesh>>();
+    app.init_resource::<Assets<StandardMaterial>>();
+    app.world.spawn(Window::default());
+    app
+}
+
+#[test]
+fn hotloads_module_manifest_changes() {
+    let base = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("../../../assets/modules");
+    let backup = base.join("backup");
+    if backup.exists() {
+        fs::remove_dir_all(&backup).unwrap();
+    }
+    fs::create_dir_all(&backup).unwrap();
+    for entry in fs::read_dir(&base).unwrap() {
+        let entry = entry.unwrap();
+        if entry.file_name() == "backup" { continue; }
+        if entry.file_type().unwrap().is_dir() {
+            let name = entry.file_name();
+            fs::rename(entry.path(), backup.join(name)).unwrap();
+        }
+    }
+    let mod1 = base.join("hotload_one");
+    fs::create_dir_all(&mod1).unwrap();
+    fs::write(
+        mod1.join("module.toml"),
+        r#"id = "m1"
+name = "Mod One"
+version = "1.0.0"
+author = "Test"
+state = "DuckHunt"
+capabilities = ["LOBBY_PAD"]
+"#,
+    )
+    .unwrap();
+
+    let mut app = test_app();
+    app.world.run_system_once(discover_modules);
+    hotload_modules(&mut app);
+    app.world.run_system_once(setup_lobby);
+
+    let mut pad_query = app.world.query::<&LobbyPad>();
+    assert_eq!(pad_query.iter(&app.world).count(), 1);
+
+    // add second module
+    let mod2 = base.join("hotload_two");
+    fs::create_dir_all(&mod2).unwrap();
+    fs::write(
+        mod2.join("module.toml"),
+        r#"id = "m2"
+name = "Mod Two"
+version = "1.0.0"
+author = "Test"
+state = "DuckHunt"
+capabilities = ["LOBBY_PAD"]
+"#,
+    )
+    .unwrap();
+    app.world.run_system_once(discover_modules);
+    app.world.run_system_once(update_lobby_pads);
+    assert_eq!(pad_query.iter(&app.world).count(), 2);
+
+    // remove second module
+    fs::remove_dir_all(&mod2).unwrap();
+    app.world.run_system_once(discover_modules);
+    app.world.run_system_once(update_lobby_pads);
+    assert_eq!(pad_query.iter(&app.world).count(), 1);
+
+    fs::remove_dir_all(mod1).unwrap();
+    for entry in fs::read_dir(&backup).unwrap() {
+        let entry = entry.unwrap();
+        fs::rename(entry.path(), base.join(entry.file_name())).unwrap();
+    }
+    fs::remove_dir_all(backup).unwrap();
+}
+


### PR DESCRIPTION
## Summary
- watch module directories and refresh lobby pads on changes
- poll server for module changes in wasm builds
- test hotloading module manifests

## Testing
- `npm run prettier`
- `cargo test -p engine`

------
https://chatgpt.com/codex/tasks/task_e_68bcbfba510483239484822b051efbfc