### PR TITLE
refactor: async cleanup task

### DIFF
--- a/server/src/email.rs
+++ b/server/src/email.rs
@@ -1,3 +1,9 @@
+//! Email utilities and rate limiting.
+//!
+//! A background task periodically purges expired entries from the rate-limit
+//! map. The task runs on the Tokio runtime and its [`JoinHandle`] is stored so
+//! it can be aborted during shutdown if necessary.
+
 use lettre::address::AddressError;
 use lettre::transport::smtp::authentication::Credentials;
 use lettre::transport::smtp::client::{Tls, TlsParameters};
@@ -7,6 +13,7 @@ use std::collections::HashMap;
 use std::sync::Mutex;
 use std::time::{Duration, Instant};
 use tokio::sync::mpsc::{self, UnboundedSender};
+use tokio::task::JoinHandle;
 
 // -- Configuration ---------------------------------------------------------
 
@@ -67,10 +74,10 @@ impl Default for SmtpConfig {
 
 static RATE_LIMITS: Lazy<Mutex<HashMap<String, Instant>>> =
     Lazy::new(|| Mutex::new(HashMap::new()));
-static CLEANUP: Lazy<()> = Lazy::new(|| {
-    std::thread::spawn(|| {
+static CLEANUP: Lazy<JoinHandle<()>> = Lazy::new(|| {
+    tokio::spawn(async move {
         loop {
-            std::thread::sleep(CLEANUP_INTERVAL);
+            tokio::time::sleep(CLEANUP_INTERVAL).await;
             let now = Instant::now();
             let mut map = match RATE_LIMITS.lock() {
                 Ok(m) => m,
@@ -78,10 +85,18 @@ static CLEANUP: Lazy<()> = Lazy::new(|| {
             };
             map.retain(|_, &mut instant| now.duration_since(instant) < RATE_LIMIT);
         }
-    });
+    })
 });
 const RATE_LIMIT: Duration = Duration::from_secs(60);
 const CLEANUP_INTERVAL: Duration = Duration::from_secs(60);
+
+/// Access the cleanup task's [`JoinHandle`].
+///
+/// The task is started on first use and can be aborted during shutdown
+/// if necessary.
+pub fn cleanup_handle() -> &'static JoinHandle<()> {
+    Lazy::force(&CLEANUP)
+}
 
 // retry behaviour
 const MAX_RETRIES: u32 = 5;
@@ -110,10 +125,12 @@ impl EmailService {
             .port(config.port)
             .timeout(Some(Duration::from_millis(config.timeout)));
 
-        let tls_params = TlsParameters::builder(config.host.clone()).build().map_err(|e| {
-            log::error!("failed to build TLS parameters: {e:?}");
-            EmailError::Smtp(e.to_string())
-        })?;
+        let tls_params = TlsParameters::builder(config.host.clone())
+            .build()
+            .map_err(|e| {
+                log::error!("failed to build TLS parameters: {e:?}");
+                EmailError::Smtp(e.to_string())
+            })?;
 
         builder = if config.smtps {
             builder.tls(Tls::Wrapper(tls_params))
@@ -135,7 +152,7 @@ impl EmailService {
 
     fn new_with_transport(from: String, transport: AsyncSmtpTransport<Tokio1Executor>) -> Self {
         // Start periodic cleanup once
-        Lazy::force(&CLEANUP);
+        cleanup_handle();
         let (tx, mut rx) = mpsc::unbounded_channel::<Message>();
         tokio::spawn(async move {
             while let Some(msg) = rx.recv().await {
@@ -143,7 +160,13 @@ impl EmailService {
                 send_with_retry(|| {
                     let mailer = mailer.clone();
                     let msg = msg.clone();
-                    async move { mailer.send(msg).await.map(|_| ()).map_err(|e| e.to_string()) }
+                    async move {
+                        mailer
+                            .send(msg)
+                            .await
+                            .map(|_| ())
+                            .map_err(|e| e.to_string())
+                    }
                 })
                 .await;
             }
@@ -299,9 +322,7 @@ mod tests {
         let attempts = AtomicUsize::new(0);
         send_with_retry(|| {
             let n = attempts.fetch_add(1, Ordering::SeqCst);
-            async move {
-                if n < 2 { Err("fail") } else { Ok(()) }
-            }
+            async move { if n < 2 { Err("fail") } else { Ok(()) } }
         })
         .await;
         assert_eq!(attempts.load(Ordering::SeqCst), 3);


### PR DESCRIPTION
## Summary
- run email rate limit cleanup on a Tokio task
- keep a handle to abort cleanup on shutdown
- document async rate limit cleanup

## Testing
- `npm run prettier`
- `cargo test -p server -- --test-threads=1`


------
https://chatgpt.com/codex/tasks/task_e_68bcc8f20380832392be13a53bc7c2eb