### PR TITLE
feat(net): add connection event stream

### DIFF
--- a/client/crates/minigames/duck_hunt/src/lib.rs
+++ b/client/crates/minigames/duck_hunt/src/lib.rs
@@ -3,6 +3,7 @@ use bevy::prelude::*;
 use bevy::render::mesh::shape::UVSphere;
 use net::{
     CurrentFrame,
+    client::ConnectionEvent,
     message::{InputFrame, Snapshot},
 };
 use platform_api::{
@@ -66,6 +67,7 @@ impl Plugin for DuckHuntPlugin {
                 apply_score_snapshots,
                 update_hud,
                 update_round_timer,
+                log_connection_events,
             ),
         );
     }
@@ -257,5 +259,11 @@ fn update_round_timer(
         for e in &mut q {
             commands.entity(e).despawn_recursive();
         }
+    }
+}
+
+fn log_connection_events(mut events: EventReader<ConnectionEvent>) {
+    for ev in events.read() {
+        info!("connection event: {ev:?}");
     }
 }

--- a/crates/net/src/lib.rs
+++ b/crates/net/src/lib.rs
@@ -20,7 +20,15 @@ impl Plugin for NetPlugin {
         app.insert_resource(CurrentFrame::default())
             .add_event::<message::InputFrame>()
             .add_event::<message::Snapshot>()
+            .add_event::<client::ConnectionEvent>()
             .add_systems(PreUpdate, advance_frame)
-            .add_systems(Update, (client::send_input_frames, client::apply_snapshots));
+            .add_systems(
+                Update,
+                (
+                    client::send_input_frames,
+                    client::apply_snapshots,
+                    client::apply_connection_events,
+                ),
+            );
     }
 }


### PR DESCRIPTION
## Summary
- register `ConnectionEvent` in `NetPlugin` and apply to Update schedule
- log connection events in DuckHunt client module

## Testing
- `npm run prettier`
- `cargo test` *(fails: system library `alsa` required by crate `alsa-sys` was not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bcc8d796a883239e6493da26c18adb