### PR TITLE
Derive Error for email service

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5284,6 +5284,7 @@ dependencies = [
  "postcard",
  "serde",
  "sqlx",
+ "thiserror 1.0.69",
  "tokio",
  "tokio-tungstenite 0.21.0",
  "tower-http",

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -20,6 +20,7 @@ clap = { version = "4", features = ["derive", "env"] }
 duck_hunt_server = { path = "../crates/minigames/duck_hunt" }
 glam = "0.24"
 postcard = { version = "1", features = ["alloc"] }
+thiserror = "1"
 
 [dev-dependencies]
 tokio-tungstenite = "0.21"

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -161,8 +161,8 @@ async fn setup(smtp: SmtpConfig) -> Result<AppState> {
     })?;
 
     let email = Arc::new(EmailService::new(smtp).map_err(|e| {
-        log::error!("failed to initialize email service: {e:?}");
-        anyhow!("{e:?}")
+        log::error!("failed to initialize email service: {e}");
+        anyhow!(e)
     })?);
 
     let rooms = room::RoomManager::new();


### PR DESCRIPTION
## Summary
- derive `thiserror::Error` for `EmailError` so variant payloads display nicely
- log formatted email service errors during startup

## Testing
- `npm run prettier`
- `cargo clippy`
- `cargo test` *(fails: linking with `cc` killed by signal 9)*
- `cargo test -p server`

------
https://chatgpt.com/codex/tasks/task_e_68bccaafb7988323b7edd83719376090