### PR TITLE
feat: gate audio with optional feature

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,9 @@ jobs:
       - name: Install wasm target
         run: rustup target add wasm32-unknown-unknown
 
+      - name: Clippy
+        run: cargo clippy -p client --all-targets --no-default-features --no-deps -- -D warnings
+
       - name: Build server
         run: cargo build -p server --release
 

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -5,7 +5,34 @@ edition = "2024"
 
 
 [dependencies]
-bevy = "0.12"
+bevy = { version = "0.12", default-features = false, features = [
+    "animation",
+    "bevy_asset",
+    "bevy_gilrs",
+    "bevy_scene",
+    "bevy_winit",
+    "bevy_core_pipeline",
+    "bevy_pbr",
+    "bevy_gltf",
+    "bevy_render",
+    "bevy_sprite",
+    "bevy_text",
+    "bevy_ui",
+    "multi-threaded",
+    "png",
+    "hdr",
+    "vorbis",
+    "x11",
+    "bevy_gizmos",
+    "android_shared_stdcxx",
+    "tonemapping_luts",
+    "default_font",
+    "webgl2",
+] }
 engine = { path = "crates/engine" }
 duck_hunt = { path = "crates/minigames/duck_hunt" }
 null_module = { path = "../crates/minigames/null_module" }
+
+[features]
+default = ["audio"]
+audio = ["bevy/bevy_audio"]

--- a/crates/minigames/null_module/Cargo.toml
+++ b/crates/minigames/null_module/Cargo.toml
@@ -4,6 +4,15 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
-bevy = "0.12"
+bevy = { version = "0.12", default-features = false, features = [
+    "bevy_render",
+    "bevy_core_pipeline",
+    "bevy_pbr",
+    "bevy_text",
+] }
 platform-api = { path = "../../platform-api" }
 anyhow = "1"
+
+[features]
+default = []
+audio = ["bevy/bevy_audio"]

--- a/crates/platform-api/Cargo.toml
+++ b/crates/platform-api/Cargo.toml
@@ -4,6 +4,18 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
-bevy = { version = "0.12", default-features = false, features = ["bevy_winit", "bevy_render", "bevy_core_pipeline", "bevy_pbr", "bevy_ui", "bevy_text", "bevy_audio", "x11"] }
+bevy = { version = "0.12", default-features = false, features = [
+    "bevy_winit",
+    "bevy_render",
+    "bevy_core_pipeline",
+    "bevy_pbr",
+    "bevy_ui",
+    "bevy_text",
+    "x11",
+] }
 bitflags = "2"
 anyhow = "1"
+
+[features]
+default = []
+audio = ["bevy/bevy_audio"]

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -1,10 +1,24 @@
-use std::{collections::HashMap, fs, path::Path};
+use std::{collections::HashMap, fs, path::Path, process::Command};
 
-use anyhow::Result;
+use anyhow::{Context, Result};
 use sha2::{Digest, Sha256};
 use walkdir::WalkDir;
 
 fn main() -> Result<()> {
+    Command::new("cargo")
+        .args([
+            "build",
+            "-p",
+            "client",
+            "--target",
+            "wasm32-unknown-unknown",
+            "--release",
+            "--features",
+            "audio",
+        ])
+        .status()
+        .context("failed to build wasm client")?;
+
     let web = Path::new("web");
     let assets_dir = Path::new("assets");
     let static_dir = Path::new("static");


### PR DESCRIPTION
## Summary
- add `audio` feature to gate ALSA-dependent Bevy audio
- build wasm client with audio via xtask
- run clippy without default features in CI

## Testing
- `npm run prettier`
- `cargo clippy -p client --all-targets --no-default-features --no-deps -- -D warnings`


------
https://chatgpt.com/codex/tasks/task_e_68bcca9a0468832392b2d7813a9d8d74