### PR TITLE
Add serial_test import for server tests

### DIFF
--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -251,6 +251,7 @@ mod tests {
     use webrtc::api::APIBuilder;
     use webrtc::api::media_engine::MediaEngine;
     use webrtc::peer_connection::configuration::RTCConfiguration;
+    use serial_test::serial;
 
     #[tokio::test]
     async fn setup_succeeds_without_env_vars() {


### PR DESCRIPTION
## Summary
- bring in `serial_test::serial` macro for server test module

## Testing
- `npm run prettier`
- `cargo test` *(fails: use of undeclared type `PgPoolOptions`)*

------
https://chatgpt.com/codex/tasks/task_e_68bcd57d786c83238e24dad7232edd41