### PR TITLE
chore: remove unused smtp error import

### DIFF
--- a/server/src/email.rs
+++ b/server/src/email.rs
@@ -8,7 +8,6 @@ use lettre::address::AddressError;
 use lettre::transport::smtp::{
     authentication::Credentials,
     client::{Tls, TlsParameters},
-    Error as SmtpError,
 };
 use lettre::{AsyncSmtpTransport, AsyncTransport, Message, Tokio1Executor};
 use once_cell::sync::Lazy;


### PR DESCRIPTION
## Summary
- tidy server email module imports by removing unused `SmtpError`

## Testing
- `npm run prettier`
- `cargo check`

------
https://chatgpt.com/codex/tasks/task_e_68bcdbcd14a88323a20f44e7f7c1a24d