### PR TITLE
Add interactive lobby help pads for docs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2232,6 +2232,7 @@ dependencies = [
  "toml",
  "wasm-bindgen-futures",
  "wasm-bindgen-test",
+ "web-sys",
 ]
 
 [[package]]

--- a/client/crates/engine/Cargo.toml
+++ b/client/crates/engine/Cargo.toml
@@ -18,6 +18,7 @@ notify = "6"
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 wasm-bindgen-futures = "0.4"
 gloo-timers = { version = "0.2", features = ["futures"] }
+web-sys = { version = "0.3", features = ["Window"] }
 
 [features]
 default = ["vehicle", "flight"]

--- a/client/crates/engine/tests/lobby.rs
+++ b/client/crates/engine/tests/lobby.rs
@@ -1,6 +1,6 @@
 use bevy::ecs::system::RunSystemOnce;
 use bevy::prelude::*;
-use engine::{discover_modules, setup_lobby, LobbyPad, ModuleRegistry};
+use engine::{discover_modules, setup_lobby, DocPad, LobbyPad, ModuleRegistry};
 use std::fs;
 use std::path::Path;
 
@@ -55,25 +55,22 @@ capabilities = ["LOBBY_PAD"]
 }
 
 #[test]
-fn shows_empty_state_when_registry_empty() {
+fn spawns_help_pads_when_registry_empty() {
     let mut app = test_app();
     app.world.run_system_once(setup_lobby);
 
-    let mut texts = app.world.query::<&Text>();
-    let mut found_msg = false;
-    let mut found_link = false;
-    for text in texts.iter(&app.world) {
-        for section in &text.sections {
-            if section.value.contains("No modules installed") {
-                found_msg = true;
-            }
-            if section.value.contains("docs/modules.md") {
-                found_link = true;
-            }
-        }
+    let pads: Vec<_> = app.world.query::<&DocPad>().iter(&app.world).collect();
+    assert_eq!(pads.len(), 5);
+    let expected = [
+        "docs/netcode.md",
+        "docs/modules.md",
+        "docs/DuckHunt.md",
+        "docs/ops.md",
+        "docs/Email.md",
+    ];
+    for url in expected {
+        assert!(pads.iter().any(|pad| pad.url == url), "missing pad for {url}");
     }
-    assert!(found_msg, "missing empty-state message");
-    assert!(found_link, "missing docs link");
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- replace static 'no modules installed' notice with interactive help pads linking to docs
- open doc URLs through `web_sys::window().open_with_url`
- test lobby spawns help pads

## Testing
- `npm run prettier`
- `cargo test -p engine`


------
https://chatgpt.com/codex/tasks/task_e_68bce224d2548323831b45093a02791d