### PR TITLE
feat: refresh service worker runtime cache

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,28 @@
       "version": "0.1.0",
       "devDependencies": {
         "husky": "^8.0.3",
-        "prettier": "^3.2.5"
+        "prettier": "^3.2.5",
+        "service-worker-mock": "^2.0.5"
+      }
+    },
+    "node_modules/browser-process-hrtime": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/browser-process-hrtime/-/browser-process-hrtime-1.0.0.tgz",
+      "integrity": "sha512-9o5UecI3GhkpM6DrXr69PblIuWxPKk9Y0jHBRhdocZ2y7YECBFCsHm79Pr3OyR2AvjhDkabFJaDJMYRazHgsow==",
+      "dev": true,
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/dom-urls": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/dom-urls/-/dom-urls-1.1.0.tgz",
+      "integrity": "sha512-LNxCeExaNbczqMVfQUyLdd+r+smG7ixIa+doeyiJ7nTmL8aZRrJhHkEYBEYVGvYv7k2DOEBh2eKthoCmWpfICg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "urijs": "^1.16.1"
+      },
+      "engines": {
+        "node": ">=0.8.0"
       }
     },
     "node_modules/husky": {
@@ -28,6 +49,50 @@
         "url": "https://github.com/sponsors/typicode"
       }
     },
+    "node_modules/lodash._basefor": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash._basefor/-/lodash._basefor-3.0.3.tgz",
+      "integrity": "sha512-6bc3b8grkpMgDcVJv9JYZAk/mHgcqMljzm7OsbmcE2FGUMmmLQTPHlh/dFqR8LA0GQ7z4K67JSotVKu5058v1A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.isarguments": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
+      "integrity": "sha512-chi4NHZlZqZD18a0imDHnZPrDeBbTtVN7GXMwuGdRH9qotxAjYs3aVLKc7zNOG9eddR5Ksd8rvFEBc9SsggPpg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.isarray": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz",
+      "integrity": "sha512-JwObCrNJuT0Nnbuecmqr5DgtuBppuCvGD9lxjFpAzwnVtdGoDQ1zig+5W8k5/6Gcn0gZ3936HDAlGd28i7sOGQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.isplainobject": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-3.2.0.tgz",
+      "integrity": "sha512-P4wZnho5curNqeEq/x292Pb57e1v+woR7DJ84DURelKB46lby8aDEGVobSaYtzHdQBWQrJSdxcCwjlGOvvdIyg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lodash._basefor": "^3.0.0",
+        "lodash.isarguments": "^3.0.0",
+        "lodash.keysin": "^3.0.0"
+      }
+    },
+    "node_modules/lodash.keysin": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/lodash.keysin/-/lodash.keysin-3.0.8.tgz",
+      "integrity": "sha512-YDB/5xkL3fBKFMDaC+cfGV00pbiJ6XoJIfRmBhv7aR6wWtbCW6IzkiWnTfkiHTF6ALD7ff83dAtB3OEaSoyQPg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lodash.isarguments": "^3.0.0",
+        "lodash.isarray": "^3.0.0"
+      }
+    },
     "node_modules/prettier": {
       "version": "3.6.2",
       "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.6.2.tgz",
@@ -42,6 +107,79 @@
       },
       "funding": {
         "url": "https://github.com/prettier/prettier?sponsor=1"
+      }
+    },
+    "node_modules/realistic-structured-clone": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/realistic-structured-clone/-/realistic-structured-clone-1.0.1.tgz",
+      "integrity": "sha512-UnQGgXdxTg+vwonhBz6VvfNFeqn/DUk0ntL/rSrN1mBOR261ZzLP3LQAFSBfIytyZYn4yue/64pZ7aN0x/RpiQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "lodash.isplainobject": "^3.0.2"
+      }
+    },
+    "node_modules/service-worker-mock": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/service-worker-mock/-/service-worker-mock-2.0.5.tgz",
+      "integrity": "sha512-yk6NCFnRWGfbOlP+IS4hEbJnGU8dVgtodAAKLxhkTPsOmaES44XVSWTNozK6KwI+p/0PDRrFsb2RjTMhvXiNkA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "dom-urls": "^1.1.0",
+        "shelving-mock-indexeddb": "^1.1.0",
+        "url-search-params": "^0.10.0",
+        "w3c-hr-time": "^1.0.1"
+      }
+    },
+    "node_modules/shelving-mock-event": {
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/shelving-mock-event/-/shelving-mock-event-1.0.12.tgz",
+      "integrity": "sha512-2F+IZ010rwV3sA/Kd2hnC1vGNycsxeBJmjkXR8+4IOlv5e+Wvj+xH+A8Cv8/Z0lUyCut/HcxSpeDccYTVtnuaQ==",
+      "dev": true,
+      "license": "0BSD",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/shelving-mock-indexeddb": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/shelving-mock-indexeddb/-/shelving-mock-indexeddb-1.1.0.tgz",
+      "integrity": "sha512-akHJAmGL/dplJ4FZNxPxVbOxMw8Ey6wAnB9+3+GCUNqPUcJaskS55GijxZtarTfAYB4XQyu+FLtjcq2Oa3e2Lg==",
+      "dev": true,
+      "license": "0BSD",
+      "dependencies": {
+        "realistic-structured-clone": "^1.0.1",
+        "shelving-mock-event": "^1.0.12"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/urijs": {
+      "version": "1.19.11",
+      "resolved": "https://registry.npmjs.org/urijs/-/urijs-1.19.11.tgz",
+      "integrity": "sha512-HXgFDgDommxn5/bIv0cnQZsPhHDA90NPHD6+c/v21U5+Sx5hoP8+dP9IZXBU1gIfvdRfhG8cel9QNPeionfcCQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/url-search-params": {
+      "version": "0.10.2",
+      "resolved": "https://registry.npmjs.org/url-search-params/-/url-search-params-0.10.2.tgz",
+      "integrity": "sha512-d6GYsr992Bo9rzTZFc9BUw3UFAAg3prE9JGVBgW2TLTbI3rSvg4VDa0BFXHMzKkWbAuhrmaFWpucpRJl+3W7Jg==",
+      "deprecated": "now available as @ungap/url-search-params",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/w3c-hr-time": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/w3c-hr-time/-/w3c-hr-time-1.0.2.tgz",
+      "integrity": "sha512-z8P5DvDNjKDoFIHK7q8r8lackT6l+jo/Ye3HOle7l9nICP9lf1Ci25fy9vHd0JOWewkIFzXIEig3TdKT7JQ5fQ==",
+      "deprecated": "Use your platform's native performance.now() and performance.timeOrigin.",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "browser-process-hrtime": "^1.0.0"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -6,10 +6,12 @@
     "format": "prettier --write .",
     "lint": "prettier --check .",
     "prettier": "prettier --check .",
-    "prepare": "husky install"
+    "prepare": "husky install",
+    "test": "node --test tests"
   },
   "devDependencies": {
     "prettier": "^3.2.5",
-    "husky": "^8.0.3"
+    "husky": "^8.0.3",
+    "service-worker-mock": "^2.0.5"
   }
 }

--- a/tests/sw-cache.test.js
+++ b/tests/sw-cache.test.js
@@ -1,0 +1,29 @@
+const test = require("node:test");
+const assert = require("node:assert");
+const fs = require("node:fs");
+const path = require("node:path");
+const makeServiceWorkerEnv = require("service-worker-mock");
+
+test("service worker serves cached response and refreshes asynchronously", async () => {
+  Object.assign(global, makeServiceWorkerEnv());
+
+  const swSrc = fs
+    .readFileSync(path.join(__dirname, "..", "web", "sw.js"), "utf8")
+    .replace("__PRECACHE_VERSION__", "test");
+  eval(swSrc);
+
+  const url = `${self.location.origin}/assets/foo.txt`;
+  const cache = await caches.open("precache-test");
+  await cache.put(url, new Response("old"));
+
+  global.fetch = () => Promise.resolve(new Response("new"));
+
+  const res = await self.trigger(
+    "fetch",
+    new FetchEvent("fetch", { request: new Request(url) }),
+  );
+  assert.strictEqual(await res.text(), "old");
+
+  const updated = await cache.match(url);
+  assert.strictEqual(await updated.text(), "new");
+});

--- a/web/sw.js
+++ b/web/sw.js
@@ -1,5 +1,6 @@
 const MANIFEST_VERSION = "__PRECACHE_VERSION__";
 const PRECACHE = `precache-${MANIFEST_VERSION}`;
+const RUNTIME = "runtime";
 
 self.addEventListener("install", (event) => {
   event.waitUntil(
@@ -26,9 +27,26 @@ self.addEventListener("activate", (event) => {
 });
 
 self.addEventListener("fetch", (event) => {
-  event.respondWith(
+  if (event.request.method !== "GET") {
+    return;
+  }
+
+  const fetchPromise = fetch(event.request).then((networkResponse) =>
     caches
-      .match(event.request)
-      .then((response) => response || fetch(event.request)),
+      .open(
+        event.request.url.startsWith(`${self.location.origin}/assets/`)
+          ? PRECACHE
+          : RUNTIME,
+      )
+      .then((cache) => {
+        cache.put(event.request, networkResponse.clone());
+        return networkResponse;
+      }),
   );
+
+  event.respondWith(
+    caches.match(event.request).then((response) => response || fetchPromise),
+  );
+
+  event.waitUntil(fetchPromise);
 });

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -90,13 +90,19 @@ fn main() -> Result<()> {
                         format!("{stem}-{hash_hex}.{ext}")
                     };
                     fs::write(module_dest.join(&hashed_name), data)?;
-                    module_manifest.insert(file_name, hashed_name);
+                    module_manifest.insert(file_name, hashed_name.clone());
+                    precache.push(format!(
+                        "/assets/modules/{module_name}/{hashed_name}"
+                    ));
                 }
             }
             fs::write(
                 module_dest.join("manifest.json"),
                 serde_json::to_string_pretty(&module_manifest)?,
             )?;
+            precache.push(format!(
+                "/assets/modules/{module_name}/manifest.json"
+            ));
         }
     }
 


### PR DESCRIPTION
## Summary
- cache runtime requests via stale-while-revalidate
- precache hashed module assets
- test service worker cache refresh

## Testing
- `npm run prettier`
- `npm test`
- `cargo test -p xtask`


------
https://chatgpt.com/codex/tasks/task_e_68bd4528dbc483239dda37869f2d702d