### PR TITLE
feat: add email metrics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4574,6 +4574,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3eb8486b569e12e2c32ad3e204dbaba5e4b5b216e9367044f25f1dba42341773"
 
 [[package]]
+name = "prometheus"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d33c28a30771f7f96db69893f78b857f7450d7e0237e9c8fc6427a81bae7ed1"
+dependencies = [
+ "cfg-if",
+ "fnv",
+ "lazy_static",
+ "memchr",
+ "parking_lot",
+ "protobuf",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "protobuf"
+version = "2.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "106dd99e98437432fed6519dedecfade6a06a73bb7b2a1e019fdd2bee5778d94"
+
+[[package]]
 name = "psm"
 version = "0.1.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5153,6 +5174,7 @@ dependencies = [
  "net",
  "once_cell",
  "postcard",
+ "prometheus",
  "serde",
  "serial_test",
  "thiserror 1.0.69",

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -21,6 +21,7 @@ glam = "0.24"
 postcard = { version = "1", features = ["alloc"] }
 thiserror = "1"
 email_address = "0.2"
+prometheus = "0.13"
 
 [dev-dependencies]
 tokio-tungstenite = "0.21"


### PR DESCRIPTION
## Summary
- track queued, sent, failed email counts and last error/latency with Prometheus metrics
- export Prometheus metrics at `/metrics`
- test email metrics for success and failure cases

## Testing
- `npm run prettier`
- `cargo test -p server`


------
https://chatgpt.com/codex/tasks/task_e_68bd45267434832394fe366121a82161