### PR TITLE
feat: show docs hint when modules missing

### DIFF
--- a/client/crates/engine/src/lib.rs
+++ b/client/crates/engine/src/lib.rs
@@ -22,7 +22,6 @@ use std::sync::mpsc::Receiver;
 #[cfg(target_arch = "wasm32")]
 use wasm_bindgen_futures::spawn_local;
 
-
 #[cfg(feature = "flight")]
 pub mod flight;
 #[cfg(feature = "vehicle")]
@@ -211,6 +210,23 @@ pub fn setup_lobby(
                     });
                 });
         }
+
+        commands.spawn((
+            Text2dBundle {
+                text: Text::from_section(
+                    "No modules installed – see Docs pads for setup instructions",
+                    TextStyle {
+                        font: font.clone(),
+                        font_size: 40.0,
+                        color: Color::WHITE,
+                    },
+                ),
+                transform: Transform::from_xyz(0.0, 2.5, 3.0)
+                    .looking_at(Vec3::new(0.0, 1.5, 5.0), Vec3::Y),
+                ..default()
+            },
+            LobbyEntity,
+        ));
     } else {
         for (i, info) in registry.modules.iter().enumerate() {
             if !info.capabilities.contains(CapabilityFlags::LOBBY_PAD) {

--- a/client/crates/engine/tests/lobby.rs
+++ b/client/crates/engine/tests/lobby.rs
@@ -1,6 +1,6 @@
 use bevy::ecs::system::RunSystemOnce;
 use bevy::prelude::*;
-use engine::{discover_modules, setup_lobby, DocPad, LobbyPad, ModuleRegistry};
+use engine::{DocPad, LobbyPad, ModuleRegistry, discover_modules, setup_lobby};
 use std::fs;
 use std::path::Path;
 
@@ -25,7 +25,8 @@ fn app_without_window() -> App {
 
 #[test]
 fn spawns_pads_for_modules() {
-    let manifest_dir = Path::new(env!("CARGO_MANIFEST_DIR")).join("../../../assets/modules/test_mod");
+    let manifest_dir =
+        Path::new(env!("CARGO_MANIFEST_DIR")).join("../../../assets/modules/test_mod");
     fs::create_dir_all(&manifest_dir).unwrap();
     fs::write(
         manifest_dir.join("module.toml"),
@@ -69,8 +70,18 @@ fn spawns_help_pads_when_registry_empty() {
         "docs/Email.md",
     ];
     for url in expected {
-        assert!(pads.iter().any(|pad| pad.url == url), "missing pad for {url}");
+        assert!(
+            pads.iter().any(|pad| pad.url == url),
+            "missing pad for {url}"
+        );
     }
+
+    let signage_present = app.world.query::<&Text>().iter(&app.world).any(|t| {
+        t.sections
+            .iter()
+            .any(|s| s.value == "No modules installed – see Docs pads for setup instructions")
+    });
+    assert!(signage_present, "missing no-modules signage");
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- show instructional sign when module registry is empty
- test lobby displays sign when no modules installed

## Testing
- `npm run prettier`
- `cargo test -p engine -j 1 --color never`


------
https://chatgpt.com/codex/tasks/task_e_68bd49f572388323977e150da3be37a6