### PR TITLE
feat(net): log send errors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3844,6 +3844,8 @@ dependencies = [
  "postcard",
  "serde",
  "tokio",
+ "tracing",
+ "tracing-subscriber",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",

--- a/crates/net/Cargo.toml
+++ b/crates/net/Cargo.toml
@@ -23,3 +23,7 @@ futures-channel = "0.3"
 wasm-bindgen = "0.2"
 web-sys = { version = "0.3", features = ["BinaryType", "MessageEvent", "WebSocket"] }
 js-sys = "0.3"
+
+[dev-dependencies]
+tracing = "0.1"
+tracing-subscriber = "0.3"


### PR DESCRIPTION
## Summary
- add DataSender trait to allow logging send failures
- report data channel send errors and test failure logging

## Testing
- `cargo test -p net`


------
https://chatgpt.com/codex/tasks/task_e_68bd4c721d588323b8b84987d7d1152b