### PR TITLE
Scale movement by delta time

### DIFF
--- a/client/crates/engine/src/flight.rs
+++ b/client/crates/engine/src/flight.rs
@@ -13,9 +13,9 @@ impl Default for FlightController {
     }
 }
 
-pub fn flight_motion(mut query: Query<(&FlightController, &mut Transform)>) {
+pub fn flight_motion(time: Res<Time>, mut query: Query<(&FlightController, &mut Transform)>) {
     for (controller, mut transform) in &mut query {
-        transform.translation.y += controller.lift;
+        transform.translation.y += controller.lift * time.delta_seconds();
     }
 }
 

--- a/client/crates/engine/src/vehicle.rs
+++ b/client/crates/engine/src/vehicle.rs
@@ -13,9 +13,9 @@ impl Default for VehicleController {
     }
 }
 
-pub fn vehicle_motion(mut query: Query<(&VehicleController, &mut Transform)>) {
+pub fn vehicle_motion(time: Res<Time>, mut query: Query<(&VehicleController, &mut Transform)>) {
     for (controller, mut transform) in &mut query {
-        transform.translation.x += controller.speed;
+        transform.translation.x += controller.speed * time.delta_seconds();
     }
 }
 

--- a/client/crates/engine/tests/motion.rs
+++ b/client/crates/engine/tests/motion.rs
@@ -1,4 +1,5 @@
 use bevy::prelude::*;
+use std::time::Duration;
 use engine::flight::{FlightController, FlightPlugin};
 use engine::vehicle::{VehicleController, VehiclePlugin};
 
@@ -7,13 +8,16 @@ fn vehicle_moves_forward() {
     let mut app = App::new();
     app.add_plugins(MinimalPlugins);
     app.add_plugins(VehiclePlugin);
+    app.world
+        .resource_mut::<Time>()
+        .advance_by(Duration::from_secs_f32(0.5));
     let entity = app
         .world
         .spawn((VehicleController { speed: 2.0 }, Transform::default()))
         .id();
-    app.update();
+    app.world.run_schedule(Update);
     let transform = app.world.get::<Transform>(entity).unwrap();
-    assert_eq!(transform.translation.x, 2.0);
+    assert_eq!(transform.translation.x, 2.0 * 0.5);
 }
 
 #[test]
@@ -21,12 +25,15 @@ fn flight_moves_up() {
     let mut app = App::new();
     app.add_plugins(MinimalPlugins);
     app.add_plugins(FlightPlugin);
+    app.world
+        .resource_mut::<Time>()
+        .advance_by(Duration::from_secs_f32(2.0));
     let entity = app
         .world
         .spawn((FlightController { lift: 3.0 }, Transform::default()))
         .id();
-    app.update();
+    app.world.run_schedule(Update);
     let transform = app.world.get::<Transform>(entity).unwrap();
-    assert_eq!(transform.translation.y, 3.0);
+    assert_eq!(transform.translation.y, 3.0 * 2.0);
 }
 


### PR DESCRIPTION
## Summary
- make vehicle controller frame-rate independent using Time resource
- make flight controller respect delta time
- update motion tests to validate delta-scaled movement

## Testing
- `cargo test -p engine`


------
https://chatgpt.com/codex/tasks/task_e_68bd6c9cc93483238e91e2b8d32de315