### PR TITLE
Handle WebSocket messages and test logging

### DIFF
--- a/server/src/room.rs
+++ b/server/src/room.rs
@@ -199,37 +199,11 @@ impl RoomManager {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use log::{LevelFilter, Log, Metadata, Record};
+    use crate::test_logger::{INIT, LOGGER};
+    use log::LevelFilter;
     use net::message::apply_delta;
     use std::sync::atomic::Ordering;
-    use std::sync::{Mutex, Once};
     use tokio::sync::mpsc;
-
-    struct TestLogger {
-        messages: Mutex<Vec<String>>,
-    }
-
-    impl Log for TestLogger {
-        fn enabled(&self, metadata: &Metadata) -> bool {
-            metadata.level() <= log::Level::Warn
-        }
-
-        fn log(&self, record: &Record) {
-            if self.enabled(record.metadata()) {
-                self.messages
-                    .lock()
-                    .unwrap()
-                    .push(record.args().to_string());
-            }
-        }
-
-        fn flush(&self) {}
-    }
-
-    static LOGGER: TestLogger = TestLogger {
-        messages: Mutex::new(Vec::new()),
-    };
-    static INIT: Once = Once::new();
 
     #[tokio::test]
     async fn updates_snapshot_after_delta() {

--- a/server/src/test_logger.rs
+++ b/server/src/test_logger.rs
@@ -1,0 +1,31 @@
+#![cfg(test)]
+
+use log::{Log, Metadata, Record};
+use std::sync::{Mutex, Once};
+
+pub struct TestLogger {
+    pub messages: Mutex<Vec<String>>,
+}
+
+impl Log for TestLogger {
+    fn enabled(&self, _: &Metadata) -> bool {
+        true
+    }
+
+    fn log(&self, record: &Record) {
+        if self.enabled(record.metadata()) {
+            self.messages
+                .lock()
+                .unwrap()
+                .push(record.args().to_string());
+        }
+    }
+
+    fn flush(&self) {}
+}
+
+pub static LOGGER: TestLogger = TestLogger {
+    messages: Mutex::new(Vec::new()),
+};
+
+pub static INIT: Once = Once::new();


### PR DESCRIPTION
## Summary
- handle WebSocket messages, replying to pings and closing on unexpected frames
- add shared test logger utilities
- cover WebSocket logging and closure behavior in tests

## Testing
- `cargo test -p server`


------
https://chatgpt.com/codex/tasks/task_e_68bd7e5dfa9c832384f42cfb1dd7f56a