### PR TITLE
feat(server): parse smtp config from cli and env

### DIFF
--- a/server/src/email.rs
+++ b/server/src/email.rs
@@ -4,6 +4,7 @@
 //! map. The task runs on the Tokio runtime and its [`JoinHandle`] is stored so
 //! it can be aborted during shutdown if necessary.
 
+use clap::{Args, ValueEnum};
 use lettre::address::AddressError;
 use lettre::transport::smtp::{
     authentication::Credentials,
@@ -25,7 +26,8 @@ use tokio::task::JoinHandle;
 
 // -- Configuration ---------------------------------------------------------
 
-#[derive(Clone, Debug, PartialEq, Eq, Serialize)]
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, ValueEnum)]
+#[clap(rename_all = "lowercase")]
 pub enum StartTls {
     Auto,
     Always,
@@ -66,15 +68,35 @@ impl std::str::FromStr for StartTls {
     }
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Args)]
 pub struct SmtpConfig {
+    #[arg(
+        long = "smtp-host",
+        env = "ARENA_SMTP_HOST",
+        default_value = "localhost"
+    )]
     pub host: String,
+    #[arg(long = "smtp-port", env = "ARENA_SMTP_PORT", default_value_t = 25)]
     pub port: u16,
+    #[arg(
+        long = "smtp-from",
+        env = "ARENA_SMTP_FROM",
+        default_value = "arena@localhost"
+    )]
     pub from: String,
+    #[arg(long = "smtp-starttls", env = "ARENA_SMTP_STARTTLS", value_enum, default_value_t = StartTls::Auto)]
     pub starttls: StartTls,
+    #[arg(long = "smtp-smtps", env = "ARENA_SMTP_SMTPS", default_value_t = false)]
     pub smtps: bool,
+    #[arg(
+        long = "smtp-timeout-ms",
+        env = "ARENA_SMTP_TIMEOUT_MS",
+        default_value_t = 10000
+    )]
     pub timeout: u64,
+    #[arg(long = "smtp-user", env = "ARENA_SMTP_USER")]
     pub user: Option<String>,
+    #[arg(long = "smtp-pass", env = "ARENA_SMTP_PASS")]
     pub pass: Option<String>,
 }
 

--- a/server/src/tests.rs
+++ b/server/src/tests.rs
@@ -29,7 +29,7 @@ fn cli_overrides_env() {
         env::set_var("ARENA_SMTP_HOST", "envhost");
     }
     let cli = Cli::try_parse_from(["prog", "--smtp-host", "clihost"]).unwrap();
-    assert_eq!(cli.smtp_host, "clihost");
+    assert_eq!(cli.smtp.host, "clihost");
     unsafe {
         env::remove_var("ARENA_SMTP_HOST");
     }
@@ -41,7 +41,7 @@ fn env_used_when_no_cli() {
         env::set_var("ARENA_SMTP_PORT", "2525");
     }
     let cli = Cli::try_parse_from(["prog"]).unwrap();
-    assert_eq!(cli.smtp_port, 2525);
+    assert_eq!(cli.smtp.port, 2525);
     unsafe {
         env::remove_var("ARENA_SMTP_PORT");
     }
@@ -49,8 +49,7 @@ fn env_used_when_no_cli() {
 
 #[test]
 fn invalid_starttls_cli_value_errors() {
-    let cli = Cli::try_parse_from(["prog", "--smtp-starttls", "bogus"]).unwrap();
-    assert!(cli.smtp_config().is_err());
+    assert!(Cli::try_parse_from(["prog", "--smtp-starttls", "bogus"]).is_err());
 }
 
 #[test]
@@ -58,8 +57,7 @@ fn invalid_starttls_env_value_errors() {
     unsafe {
         env::set_var("ARENA_SMTP_STARTTLS", "bogus");
     }
-    let cli = Cli::try_parse_from(["prog"]).unwrap();
-    assert!(cli.smtp_config().is_err());
+    assert!(Cli::try_parse_from(["prog"]).is_err());
     unsafe {
         env::remove_var("ARENA_SMTP_STARTTLS");
     }


### PR DESCRIPTION
## Summary
- parse SMTP configuration from CLI flags and ARENA_SMTP_* env vars
- flatten SmtpConfig into CLI parsing

## Testing
- `npm run prettier`
- `cargo test -p server`


------
https://chatgpt.com/codex/tasks/task_e_68bd87bab088832382be81c33b0d10cf