### PR TITLE
Add skeleton editor crate with level export hooks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1653,6 +1653,7 @@ version = "0.1.0"
 dependencies = [
  "bevy",
  "duck_hunt",
+ "editor",
  "engine",
  "null_module",
  "physics",
@@ -2135,6 +2136,16 @@ dependencies = [
  "rfc6979",
  "signature",
  "spki",
+]
+
+[[package]]
+name = "editor"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "platform-api",
+ "serde",
+ "toml",
 ]
 
 [[package]]
@@ -5208,6 +5219,7 @@ dependencies = [
  "axum",
  "clap",
  "duck_hunt_server",
+ "editor",
  "email_address",
  "env_logger",
  "futures-util",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ members = [
     "client",
     "crates/net",
     "crates/platform-api",
+    "crates/editor",
     "xtask",
     "crates/minigames/duck_hunt",
     "crates/minigames/null_module",

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -33,6 +33,7 @@ engine = { path = "crates/engine" }
 duck_hunt = { path = "crates/minigames/duck_hunt" }
 null_module = { path = "../crates/minigames/null_module" }
 physics = { path = "crates/physics" }
+editor = { path = "../crates/editor" }
 
 [features]
 default = ["audio"]

--- a/crates/editor/Cargo.toml
+++ b/crates/editor/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "editor"
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]
+anyhow = "1"
+serde = { version = "1", features = ["derive"] }
+toml = "0.8"
+platform-api = { path = "../platform-api" }
+

--- a/crates/editor/src/client.rs
+++ b/crates/editor/src/client.rs
@@ -1,0 +1,33 @@
+use crate::level::Level;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum EditorMode {
+    FirstPerson,
+    TopDown,
+    PrefabPalette,
+    CsgBrush,
+    SplineVolume,
+}
+
+pub struct EditorClient {
+    pub mode: EditorMode,
+}
+
+impl EditorClient {
+    pub fn new() -> Self {
+        Self { mode: EditorMode::FirstPerson }
+    }
+
+    pub fn set_mode(&mut self, mode: EditorMode) {
+        self.mode = mode;
+    }
+
+    /// Store level data using the browser's OPFS/IndexedDB.
+    ///
+    /// This is a placeholder implementation. The actual
+    /// Web APIs would be invoked from WASM.
+    #[allow(unused_variables)]
+    pub fn store_level_locally(&self, level: &Level) {
+        // TODO: implement OPFS/IndexedDB persistence
+    }
+}

--- a/crates/editor/src/level.rs
+++ b/crates/editor/src/level.rs
@@ -1,0 +1,35 @@
+use anyhow::Result;
+use serde::{Deserialize, Serialize};
+use std::fs;
+use std::path::Path;
+
+#[derive(Serialize, Deserialize, Default, Debug)]
+pub struct Level {
+    pub id: String,
+    pub name: String,
+}
+
+impl Level {
+    pub fn new(id: impl Into<String>, name: impl Into<String>) -> Self {
+        Self { id: id.into(), name: name.into() }
+    }
+}
+
+/// Persist the level to the assets directory.
+pub fn export_level(level: &Level) -> Result<()> {
+    let dir = Path::new("assets").join("levels").join(&level.id);
+    fs::create_dir_all(&dir)?;
+    let path = dir.join("level.toml");
+    let toml = toml::to_string_pretty(level)?;
+    fs::write(path, toml)?;
+    Ok(())
+}
+
+/// Export an additional binary referenced by the level.
+pub fn export_binary(level_id: &str, name: &str, data: &[u8]) -> Result<()> {
+    let dir = Path::new("assets").join("levels").join(level_id);
+    fs::create_dir_all(&dir)?;
+    let path = dir.join(name);
+    fs::write(path, data)?;
+    Ok(())
+}

--- a/crates/editor/src/lib.rs
+++ b/crates/editor/src/lib.rs
@@ -1,0 +1,7 @@
+pub mod client;
+pub mod level;
+pub mod server;
+
+pub use client::{EditorClient, EditorMode};
+pub use level::{Level, export_binary, export_level};
+pub use server::{play_in_editor, validate_level, EditorServer};

--- a/crates/editor/src/server.rs
+++ b/crates/editor/src/server.rs
@@ -1,0 +1,20 @@
+use anyhow::Result;
+use platform_api::ModuleContext;
+
+use crate::level::Level;
+
+pub struct EditorServer;
+
+/// Validate the provided level using server-side rules.
+#[allow(unused_variables)]
+pub fn validate_level(ctx: &mut ModuleContext, level: &Level) -> Result<()> {
+    // TODO: perform server-side validation of the level data
+    Ok(())
+}
+
+/// Hook for playing the level inside the editor environment.
+#[allow(unused_variables)]
+pub fn play_in_editor(ctx: &mut ModuleContext, level: &Level) -> Result<()> {
+    // TODO: bridge between the editor and running modules
+    Ok(())
+}

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -22,6 +22,7 @@ postcard = { version = "1", features = ["alloc"] }
 thiserror = "1"
 email_address = "0.2"
 prometheus = "0.13"
+editor = { path = "../crates/editor" }
 
 [dev-dependencies]
 tokio-tungstenite = "0.21"


### PR DESCRIPTION
## Summary
- introduce `editor` crate with client and server modules
- support level export stubs and editor modes
- wire editor crate into workspace, client, and server

## Testing
- `npm run prettier`
- `cargo test -p editor`
- `cargo check -p client` *(fails: cannot find type `KinematicCharacterController`)*
- `cargo check -p server`


------
https://chatgpt.com/codex/tasks/task_e_68bd8cda4a3c8323af7d19eb4a864c4a