### PR TITLE
Add editor, leaderboard, analytics, and purchases docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ cargo run -p xtask
 cargo run -p server
 ```
 
-For details on the networking model see the [Netcode guide](docs/netcode.md). To extend gameplay, follow the [Module guide](docs/modules.md) or the example [Duck Hunt module](docs/DuckHunt.md). Email configuration is covered in the [Email guide](docs/Email.md).
+For details on the networking model see the [Netcode guide](docs/netcode.md). To extend gameplay, follow the [Module guide](docs/modules.md) or the example [Duck Hunt module](docs/DuckHunt.md). Email configuration is covered in the [Email guide](docs/Email.md). Guidance for the in-game editor, leaderboard service, analytics collection, and purchase verification can be found in the [Editor](docs/Editor.md), [Leaderboards](docs/Leaderboards.md), [Analytics](docs/Analytics.md), and [Purchases](docs/Purchases.md) guides respectively.
 
 ## Running
 
@@ -58,6 +58,10 @@ Additional resources:
 - [Netcode design](docs/netcode.md)
 - [Deployment and operations](docs/ops.md)
 - [Email configuration](docs/Email.md)
+- [Editor usage](docs/Editor.md)
+- [Leaderboards](docs/Leaderboards.md)
+- [Analytics](docs/Analytics.md)
+- [Purchases](docs/Purchases.md)
 
 ## Documentation
 
@@ -68,3 +72,7 @@ Documentation lives under `docs/`:
 - [Modules](docs/modules.md)
 - [Duck Hunt](docs/DuckHunt.md)
 - [Email](docs/Email.md)
+- [Editor](docs/Editor.md)
+- [Leaderboards](docs/Leaderboards.md)
+- [Analytics](docs/Analytics.md)
+- [Purchases](docs/Purchases.md)

--- a/docs/Analytics.md
+++ b/docs/Analytics.md
@@ -1,0 +1,35 @@
+# Analytics
+
+Arena can record gameplay events for later analysis.
+
+## Configuration
+
+| Env var                    | CLI flag               | Description                     | Default |
+| -------------------------- | ---------------------- | ------------------------------- | ------- |
+| `ARENA_ANALYTICS_ENDPOINT` | `--analytics-endpoint` | HTTP endpoint to receive events | -       |
+| `ARENA_ANALYTICS_BATCH`    | `--analytics-batch`    | Number of events per upload     | `20`    |
+| `ARENA_ANALYTICS_ENABLED`  | `--analytics`          | Enable analytics collection     | `false` |
+
+## Usage
+
+Enable analytics and run the server:
+
+```bash
+ARENA_ANALYTICS_ENABLED=true \
+ARENA_ANALYTICS_ENDPOINT=https://example.com/events \
+cargo run -p server
+```
+
+Events are queued and sent in batches to the configured endpoint.
+
+## Integration
+
+Import the `analytics` crate and call `track_event` where appropriate:
+
+```rust
+use analytics::track_event;
+
+track_event("player_jump", &["height", "2.3"]);
+```
+
+Attach `AnalyticsPlugin` to the server to automatically forward events.

--- a/docs/Editor.md
+++ b/docs/Editor.md
@@ -1,0 +1,37 @@
+# Editor
+
+This guide covers configuration and use of Arena's in-game level editor.
+
+## Configuration
+
+| Env var               | CLI flag          | Description                        | Default         |
+| --------------------- | ----------------- | ---------------------------------- | --------------- |
+| `ARENA_EDITOR`        | `--editor`        | Enable the editor on startup       | `false`         |
+| `ARENA_EDITOR_ASSETS` | `--editor-assets` | Directory containing editor assets | `assets/editor` |
+
+## Usage
+
+Enable the editor and run the server:
+
+```bash
+ARENA_EDITOR=true cargo run -p server
+```
+
+Press `F1` in the client to toggle the editor UI. Create or modify entities,
+then save the scene to disk.
+
+## Integration
+
+The editor systems are provided by the `editor` crate. Add `editor` as a
+dependency and register `EditorPlugin` on both client and server:
+
+```rust
+use editor::EditorPlugin;
+
+App::new()
+    .add_plugins(DefaultPlugins)
+    .add_plugins(EditorPlugin)
+    .run();
+```
+
+Assets saved by the editor can be loaded by other modules at runtime.

--- a/docs/Leaderboards.md
+++ b/docs/Leaderboards.md
@@ -1,0 +1,36 @@
+# Leaderboards
+
+This guide describes how to configure and use Arena's leaderboard service.
+
+## Configuration
+
+| Env var                 | CLI flag            | Description                     | Default                   |
+| ----------------------- | ------------------- | ------------------------------- | ------------------------- |
+| `ARENA_LEADERBOARD_DB`  | `--leaderboard-db`  | Database URL for storing scores | `sqlite://leaderboard.db` |
+| `ARENA_LEADERBOARD_MAX` | `--leaderboard-max` | Maximum entries per leaderboard | `100`                     |
+
+## Usage
+
+Post scores via HTTP:
+
+```bash
+curl -X POST https://server/leaderboard -d '{ "player": "Alice", "score": 42 }'
+```
+
+Retrieve the top standings:
+
+```bash
+curl https://server/leaderboard/top
+```
+
+## Integration
+
+The `leaderboard` crate exposes an API for submitting and querying scores.
+Register `LeaderboardPlugin` on the server to persist results and on the
+client to display standings.
+
+```rust
+use leaderboard::LeaderboardPlugin;
+
+App::new().add_plugins(LeaderboardPlugin);
+```

--- a/docs/Purchases.md
+++ b/docs/Purchases.md
@@ -1,0 +1,27 @@
+# Purchases
+
+Arena supports optional in-app purchases for cosmetics and modules.
+
+## Configuration
+
+| Env var                     | CLI flag                | Description                        | Default |
+| --------------------------- | ----------------------- | ---------------------------------- | ------- |
+| `ARENA_PURCHASE_VERIFY_URL` | `--purchase-verify-url` | Endpoint for receipt verification  | -       |
+| `ARENA_PURCHASE_PUBLIC_KEY` | `--purchase-public-key` | Public key for validating receipts | -       |
+| `ARENA_PURCHASE_TIMEOUT_MS` | `--purchase-timeout-ms` | Verification request timeout       | `5000`  |
+
+## Usage
+
+When a client completes a transaction, it sends the receipt to the server.
+The server verifies the receipt and unlocks the item:
+
+```bash
+curl -X POST https://server/purchases/verify -d @receipt.json
+```
+
+## Integration
+
+Purchase handling is implemented in the `platform-api` crate. Register
+`PurchasesPlugin` on the server to accept verification requests and
+update player inventory. The client invokes the platform SDK and forwards
+receipts via the `platform-api` utilities.


### PR DESCRIPTION
## Summary
- document in-game editor configuration and integration
- add leaderboard, analytics, and purchases guides
- link new documentation from README

## Testing
- `npm run prettier`


------
https://chatgpt.com/codex/tasks/task_e_68bd95ab39788323a1ad3ef403c0f7db