### PR TITLE
Add render crate with WebGL2 fallback

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1327,6 +1327,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "bevy_webgl2"
+version = "0.12.0"
+dependencies = [
+ "bevy",
+]
+
+[[package]]
 name = "bevy_window"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1699,6 +1706,7 @@ dependencies = [
  "engine",
  "null_module",
  "physics",
+ "render",
  "wasm-bindgen",
  "wee_alloc",
 ]
@@ -5140,6 +5148,15 @@ name = "regex-syntax"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "caf4aa5b0f434c91fe5c7f1ecb6a5ece2130b02ad2a590589dda5146df959001"
+
+[[package]]
+name = "render"
+version = "0.1.0"
+dependencies = [
+ "bevy",
+ "bevy_webgl2",
+ "uuid",
+]
 
 [[package]]
 name = "renderdoc-sys"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,4 +11,5 @@ members = [
     "crates/minigames/null_module",
     "crates/analytics",
     "crates/leaderboard",
+    "crates/render",
 ]

--- a/README.md
+++ b/README.md
@@ -19,6 +19,12 @@ cargo build --target wasm32-unknown-unknown
 wasm-bindgen --target web --out-dir ../web/pkg target/wasm32-unknown-unknown/debug/client.wasm
 ```
 
+To enable the WebGL2 fallback, build the client with the `webgl2` feature:
+
+```
+cargo build --target wasm32-unknown-unknown --features webgl2
+```
+
 ### Server
 
 From the repository root:

--- a/client/src/main.rs
+++ b/client/src/main.rs
@@ -5,6 +5,7 @@ use duck_hunt::DuckHuntPlugin;
 use engine::{AppExt, EnginePlugin};
 use null_module::NullModule;
 use physics::PhysicsPlugin;
+use render::RenderPlugin;
 
 #[cfg(all(target_arch = "wasm32", not(target_os = "emscripten")))]
 #[global_allocator]
@@ -12,7 +13,7 @@ static ALLOC: wee_alloc::WeeAlloc = wee_alloc::WeeAlloc::INIT;
 
 fn main() {
     App::new()
-        .add_plugins(DefaultPlugins)
+        .add_plugins(RenderPlugin)
         .add_plugins(PhysicsPlugin)
         .add_plugins(EnginePlugin)
         .add_game_module::<DuckHuntPlugin>()

--- a/crates/bevy_webgl2/Cargo.toml
+++ b/crates/bevy_webgl2/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "bevy_webgl2"
+version = "0.12.0"
+edition = "2024"
+
+[dependencies]
+bevy = { version = "0.12", default-features = false, features = ["bevy_winit", "bevy_render"] }

--- a/crates/bevy_webgl2/src/lib.rs
+++ b/crates/bevy_webgl2/src/lib.rs
@@ -1,0 +1,7 @@
+use bevy::prelude::*;
+
+pub struct WebGL2Plugin;
+
+impl Plugin for WebGL2Plugin {
+    fn build(&self, _app: &mut App) {}
+}

--- a/crates/render/Cargo.toml
+++ b/crates/render/Cargo.toml
@@ -1,8 +1,7 @@
 [package]
-name = "client"
+name = "render"
 version = "0.1.0"
 edition = "2024"
-
 
 [dependencies]
 bevy = { version = "0.12", default-features = false, features = [
@@ -28,18 +27,9 @@ bevy = { version = "0.12", default-features = false, features = [
     "tonemapping_luts",
     "default_font",
 ] }
-engine = { path = "crates/engine" }
-duck_hunt = { path = "crates/minigames/duck_hunt" }
-null_module = { path = "../crates/minigames/null_module" }
-physics = { path = "crates/physics" }
-editor = { path = "../crates/editor" }
-render = { path = "../crates/render" }
+bevy_webgl2 = { path = "../bevy_webgl2", optional = true }
+uuid = { version = "1", default-features = false, features = ["js"] }
 
 [features]
-default = ["audio"]
-audio = ["bevy/bevy_audio"]
-webgl2 = ["render/webgl2"]
-
-[target.'cfg(target_arch = "wasm32")'.dependencies]
-wee_alloc = { version = "0.4" }
-wasm-bindgen = "0.2"
+default = []
+webgl2 = ["bevy/webgl2", "bevy_webgl2"]

--- a/crates/render/src/lib.rs
+++ b/crates/render/src/lib.rs
@@ -1,0 +1,15 @@
+use bevy::prelude::*;
+
+#[cfg(feature = "webgl2")]
+use bevy_webgl2::WebGL2Plugin;
+
+pub struct RenderPlugin;
+
+impl Plugin for RenderPlugin {
+    fn build(&self, app: &mut App) {
+        app.add_plugins(DefaultPlugins);
+
+        #[cfg(feature = "webgl2")]
+        app.add_plugins(WebGL2Plugin);
+    }
+}


### PR DESCRIPTION
## Summary
- add render crate with optional WebGL2 support
- expose render crate to client and document WebGL2 build feature

## Testing
- `cargo build --manifest-path client/Cargo.toml --target wasm32-unknown-unknown` *(fails: The wasm32-unknown-unknown targets are not supported by default; you may need to enable the "wasm_js" configuration flag)*
- `cargo build --manifest-path client/Cargo.toml --target wasm32-unknown-unknown --features webgl2` *(fails: The wasm32-unknown-unknown targets are not supported by default; you may need to enable the "wasm_js" configuration flag)*

------
https://chatgpt.com/codex/tasks/task_e_68bd95b6d6d883238b2aa30ae094ead5