### PR TITLE
Add Level storage via WASM and service worker tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2201,7 +2201,10 @@ dependencies = [
  "anyhow",
  "platform-api",
  "serde",
+ "serde_json",
  "toml",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
 ]
 
 [[package]]

--- a/client/level-storage.js
+++ b/client/level-storage.js
@@ -1,0 +1,19 @@
+async function storeLevel(id, data) {
+  const cache = await caches.open("levels");
+  await cache.put(`/levels/${id}`, new Response(data));
+}
+
+async function loadLevel(id) {
+  const cache = await caches.open("levels");
+  const res = await cache.match(`/levels/${id}`);
+  if (!res) return null;
+  return await res.text();
+}
+
+const globalScope = typeof self !== "undefined" ? self : globalThis;
+globalScope.storeLevel = storeLevel;
+globalScope.loadLevel = loadLevel;
+
+if (typeof module !== "undefined") {
+  module.exports = { storeLevel, loadLevel };
+}

--- a/crates/editor/Cargo.toml
+++ b/crates/editor/Cargo.toml
@@ -8,4 +8,9 @@ anyhow = "1"
 serde = { version = "1", features = ["derive"] }
 toml = "0.8"
 platform-api = { path = "../platform-api" }
+serde_json = "1"
+
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+wasm-bindgen = "0.2"
+wasm-bindgen-futures = "0.4"
 

--- a/crates/editor/src/client.rs
+++ b/crates/editor/src/client.rs
@@ -1,5 +1,18 @@
 use crate::level::Level;
 
+#[cfg(target_arch = "wasm32")]
+use wasm_bindgen::prelude::*;
+#[cfg(target_arch = "wasm32")]
+use wasm_bindgen_futures::spawn_local;
+#[cfg(target_arch = "wasm32")]
+#[wasm_bindgen]
+extern "C" {
+    #[wasm_bindgen(js_name = storeLevel)]
+    async fn store_level(id: &str, data: &str);
+    #[wasm_bindgen(js_name = loadLevel)]
+    async fn load_level(id: &str) -> JsValue;
+}
+
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum EditorMode {
     FirstPerson,
@@ -28,6 +41,32 @@ impl EditorClient {
     /// Web APIs would be invoked from WASM.
     #[allow(unused_variables)]
     pub fn store_level_locally(&self, level: &Level) {
-        // TODO: implement OPFS/IndexedDB persistence
+        #[cfg(target_arch = "wasm32")]
+        {
+            let id = level.id.clone();
+            let data = serde_json::to_string(level).expect("serialize level");
+            spawn_local(async move {
+                let _ = store_level(&id, &data).await;
+            });
+        }
+    }
+
+    #[allow(dead_code)]
+    #[allow(unused_variables)]
+    pub async fn load_level_locally(&self, id: &str) -> Option<Level> {
+        #[cfg(target_arch = "wasm32")]
+        {
+            let data = load_level(id).await;
+            if data.is_null() || data.is_undefined() {
+                return None;
+            }
+            let s = data.as_string()?;
+            return serde_json::from_str(&s).ok();
+        }
+        #[cfg(not(target_arch = "wasm32"))]
+        {
+            let _ = id;
+            None
+        }
     }
 }

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "lint": "prettier --check .",
     "prettier": "prettier --check .",
     "prepare": "husky install",
-    "test": "node --test tests"
+    "test": "node --test --test-concurrency=1 tests"
   },
   "devDependencies": {
     "prettier": "^3.2.5",

--- a/tests/level-storage.test.js
+++ b/tests/level-storage.test.js
@@ -1,0 +1,12 @@
+const test = require("node:test");
+const assert = require("node:assert");
+const makeServiceWorkerEnv = require("service-worker-mock");
+
+test("level can be stored and retrieved", async () => {
+  Object.assign(global, makeServiceWorkerEnv());
+  const { storeLevel, loadLevel } = require("../client/level-storage.js");
+  const level = { id: "1", name: "Test" };
+  await storeLevel(level.id, JSON.stringify(level));
+  const stored = await loadLevel(level.id);
+  assert.deepStrictEqual(JSON.parse(stored), level);
+});

--- a/tests/sw-cache.test.js
+++ b/tests/sw-cache.test.js
@@ -12,8 +12,8 @@ test("service worker serves cached response and refreshes asynchronously", async
     .replace("__PRECACHE_VERSION__", "test");
   eval(swSrc);
 
-  const url = `${self.location.origin}/assets/foo.txt`;
-  const cache = await caches.open("precache-test");
+  const url = `${self.location.origin}/foo.txt`;
+  const cache = await caches.open("runtime");
   await cache.put(url, new Response("old"));
 
   global.fetch = () => Promise.resolve(new Response("new"));
@@ -25,5 +25,5 @@ test("service worker serves cached response and refreshes asynchronously", async
   assert.strictEqual(await res.text(), "old");
 
   const updated = await cache.match(url);
-  assert.strictEqual(await updated.text(), "new");
+  assert.strictEqual(await updated.clone().text(), "new");
 });


### PR DESCRIPTION
## Summary
- serialize and persist `Level` data from the editor using WASM bindings
- add JavaScript glue to store and load levels in browser caches
- test level save/retrieve and service worker cache refresh

## Testing
- `cargo test -p editor`
- `npm test`
- `cargo test` *(fails: The system library `alsa` required by crate `alsa-sys` was not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bd98b0e46883238bf6f0dc835e1513