### PR TITLE
feat(editor): add level validation

### DIFF
--- a/crates/editor/Cargo.toml
+++ b/crates/editor/Cargo.toml
@@ -9,11 +9,11 @@ serde = { version = "1", features = ["derive"] }
 toml = "0.8"
 platform-api = { path = "../platform-api" }
 serde_json = "1"
+bevy_ecs = { version = "0.12", default-features = false }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 wasm-bindgen = "0.2"
 wasm-bindgen-futures = "0.4"
-bevy_ecs = { version = "0.12", default-features = false }
 
 [dev-dependencies]
 

--- a/crates/editor/src/level.rs
+++ b/crates/editor/src/level.rs
@@ -8,12 +8,35 @@ use std::path::Path;
 pub struct Level {
     pub id: String,
     pub name: String,
+    /// External asset identifiers that must exist for the level to load.
+    #[serde(default)]
+    pub references: Vec<String>,
+    /// Areas where players can spawn when the level loads.
+    #[serde(default)]
+    pub spawn_zones: Vec<SpawnZone>,
+    /// Estimated number of entities the level will spawn at runtime.
+    #[serde(default)]
+    pub entity_count: usize,
 }
 
 impl Level {
     pub fn new(id: impl Into<String>, name: impl Into<String>) -> Self {
-        Self { id: id.into(), name: name.into() }
+        Self {
+            id: id.into(),
+            name: name.into(),
+            references: Vec::new(),
+            spawn_zones: Vec::new(),
+            entity_count: 0,
+        }
     }
+}
+
+/// Defines a circular area players may spawn in.
+#[derive(Serialize, Deserialize, Clone, Debug)]
+pub struct SpawnZone {
+    pub x: f32,
+    pub y: f32,
+    pub radius: f32,
 }
 
 /// Persist the level to the assets directory.

--- a/crates/editor/src/lib.rs
+++ b/crates/editor/src/lib.rs
@@ -3,5 +3,5 @@ pub mod level;
 pub mod server;
 
 pub use client::{EditorClient, EditorMode};
-pub use level::{Level, export_binary, export_level};
-pub use server::{play_in_editor, validate_level, EditorServer};
+pub use level::{Level, SpawnZone, export_binary, export_level};
+pub use server::{AssetRegistry, EditorServer, play_in_editor, validate_level};

--- a/crates/editor/src/server.rs
+++ b/crates/editor/src/server.rs
@@ -1,9 +1,15 @@
-use anyhow::{bail, Result};
+use anyhow::{Context, Result, bail};
+use bevy_ecs::prelude::Resource;
 use platform_api::ModuleContext;
+use std::collections::HashSet;
 
 use crate::level::Level;
 
 pub struct EditorServer;
+
+/// Simple registry of asset identifiers available to the editor.
+#[derive(Resource, Default)]
+pub struct AssetRegistry(pub HashSet<String>);
 
 /// Validate the provided level using server-side rules.
 #[allow(unused_variables)]
@@ -16,9 +22,45 @@ pub fn validate_level(ctx: &mut ModuleContext, level: &Level) -> Result<()> {
         bail!("level name cannot be empty");
     }
 
+    // Verify referenced assets exist
+    if !level.references.is_empty() {
+        let registry = ctx
+            .world()
+            .get_resource::<AssetRegistry>()
+            .context("asset registry missing")?;
+        for r in &level.references {
+            if !registry.0.contains(r) {
+                bail!("missing asset reference: {}", r);
+            }
+        }
+    }
+
+    // Spawn zone validation
+    if level.spawn_zones.is_empty() {
+        bail!("level must define at least one spawn zone");
+    }
+    const WORLD_BOUND: f32 = 1000.0;
+    for (i, z) in level.spawn_zones.iter().enumerate() {
+        if z.radius <= 0.0 {
+            bail!("spawn zone {} has non-positive radius", i);
+        }
+        if z.x.abs() > WORLD_BOUND || z.y.abs() > WORLD_BOUND {
+            bail!("spawn zone {} out of bounds", i);
+        }
+    }
+
     // Gameplay/performance checks (basic limits)
     if level.id.len() > 64 || level.name.len() > 64 {
         bail!("level metadata too long");
+    }
+
+    const ENTITY_LIMIT: usize = 1000;
+    if level.entity_count > ENTITY_LIMIT {
+        bail!(
+            "level exceeds entity budget: {}/{}",
+            level.entity_count,
+            ENTITY_LIMIT
+        );
     }
 
     // Ensure no other level is currently active
@@ -41,6 +83,9 @@ pub fn play_in_editor(ctx: &mut ModuleContext, level: &Level) -> Result<()> {
     ctx.world().insert_resource(Level {
         id: level.id.clone(),
         name: level.name.clone(),
+        references: level.references.clone(),
+        spawn_zones: level.spawn_zones.clone(),
+        entity_count: level.entity_count,
     });
 
     Ok(())

--- a/crates/editor/tests/server.rs
+++ b/crates/editor/tests/server.rs
@@ -1,5 +1,5 @@
 use bevy_ecs::prelude::*;
-use editor::{play_in_editor, validate_level, Level};
+use editor::{AssetRegistry, Level, SpawnZone, play_in_editor, validate_level};
 use platform_api::ModuleContext;
 
 #[test]
@@ -14,11 +14,53 @@ fn invalid_level_is_rejected() {
 fn play_in_editor_starts_session() {
     let mut world = World::new();
     let mut ctx = ModuleContext::new(&mut world);
-    let level = Level::new("test-level", "Test Level");
+    let mut level = Level::new("test-level", "Test Level");
+    level.spawn_zones.push(SpawnZone {
+        x: 0.0,
+        y: 0.0,
+        radius: 5.0,
+    });
 
     play_in_editor(&mut ctx, &level).expect("should start editor session");
 
     let stored = ctx.world().get_resource::<Level>().expect("level missing");
     assert_eq!(stored.id, "test-level");
     assert_eq!(stored.name, "Test Level");
+}
+
+#[test]
+fn missing_reference_is_rejected() {
+    let mut world = World::new();
+    world.insert_resource(AssetRegistry::default());
+    let mut ctx = ModuleContext::new(&mut world);
+    let mut level = Level::new("lvl", "Lvl");
+    level.references.push("missing_asset".into());
+    assert!(validate_level(&mut ctx, &level).is_err());
+}
+
+#[test]
+fn illegal_spawn_zone_is_rejected() {
+    let mut world = World::new();
+    let mut ctx = ModuleContext::new(&mut world);
+    let mut level = Level::new("lvl", "Lvl");
+    level.spawn_zones.push(SpawnZone {
+        x: 2000.0,
+        y: 0.0,
+        radius: 10.0,
+    });
+    assert!(validate_level(&mut ctx, &level).is_err());
+}
+
+#[test]
+fn perf_budget_is_enforced() {
+    let mut world = World::new();
+    let mut ctx = ModuleContext::new(&mut world);
+    let mut level = Level::new("lvl", "Lvl");
+    level.spawn_zones.push(SpawnZone {
+        x: 0.0,
+        y: 0.0,
+        radius: 10.0,
+    });
+    level.entity_count = 2000;
+    assert!(validate_level(&mut ctx, &level).is_err());
 }


### PR DESCRIPTION
## Summary
- validate level asset references, spawn zones, and entity budgets
- expand Level with references, spawn zones, and entity count
- add tests for missing assets, bad spawn zones, and perf limits

## Testing
- `npm run prettier`
- `cargo test -p editor`

------
https://chatgpt.com/codex/tasks/task_e_68bda54105fc8323866aff13f15784a6