### PR TITLE
feat(analytics): add pluggable sinks and event store

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -175,6 +175,7 @@ dependencies = [
 name = "analytics"
 version = "0.1.0"
 dependencies = [
+ "httpmock",
  "opentelemetry",
  "prometheus",
  "reqwest",
@@ -312,6 +313,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
+name = "ascii-canvas"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8824ecca2e851cec16968d54a01dd372ef8f95b244fb84b84e70128be347c3c6"
+dependencies = [
+ "term",
+]
+
+[[package]]
 name = "ash"
 version = "0.37.3+1.3.251"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -398,6 +408,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "assert-json-diff"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47e4f2b81832e72834d7518d8487a0396a28cc408186a2e8854c0f98011faf12"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "async-attributes"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3203e79f4dd9bdda415ed03cf14dae5a2bf775c683a00f94e9cd1faf0f596e5"
+dependencies = [
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "async-broadcast"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -450,10 +480,43 @@ version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "279cf904654eeebfa37ac9bb1598880884924aab82e290aa65c9e77a0e142e06"
 dependencies = [
- "async-lock",
+ "async-lock 2.8.0",
  "autocfg",
  "blocking",
  "futures-lite 1.13.0",
+]
+
+[[package]]
+name = "async-global-executor"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05b1b633a2115cd122d73b955eadd9916c18c8f510ec9cd1686404c60ad1c29c"
+dependencies = [
+ "async-channel 2.5.0",
+ "async-executor",
+ "async-io",
+ "async-lock 3.4.1",
+ "blocking",
+ "futures-lite 2.6.1",
+ "once_cell",
+]
+
+[[package]]
+name = "async-io"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19634d6336019ef220f09fd31168ce5c184b295cbf80345437cc36094ef223ca"
+dependencies = [
+ "async-lock 3.4.1",
+ "cfg-if 1.0.3",
+ "concurrent-queue",
+ "futures-io",
+ "futures-lite 2.6.1",
+ "parking",
+ "polling",
+ "rustix",
+ "slab",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -463,6 +526,90 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "287272293e9d8c41773cec55e365490fe034813a2f172f502d6ddcf75b2f582b"
 dependencies = [
  "event-listener 2.5.3",
+]
+
+[[package]]
+name = "async-lock"
+version = "3.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fd03604047cee9b6ce9de9f70c6cd540a0520c813cbd49bae61f33ab80ed1dc"
+dependencies = [
+ "event-listener 5.4.1",
+ "event-listener-strategy",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-object-pool"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "333c456b97c3f2d50604e8b2624253b7f787208cb72eb75e64b0ad11b221652c"
+dependencies = [
+ "async-std",
+]
+
+[[package]]
+name = "async-process"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "65daa13722ad51e6ab1a1b9c01299142bc75135b337923cfa10e79bbbd669f00"
+dependencies = [
+ "async-channel 2.5.0",
+ "async-io",
+ "async-lock 3.4.1",
+ "async-signal",
+ "async-task",
+ "blocking",
+ "cfg-if 1.0.3",
+ "event-listener 5.4.1",
+ "futures-lite 2.6.1",
+ "rustix",
+]
+
+[[package]]
+name = "async-signal"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f567af260ef69e1d52c2b560ce0ea230763e6fbb9214a85d768760a920e3e3c1"
+dependencies = [
+ "async-io",
+ "async-lock 3.4.1",
+ "atomic-waker",
+ "cfg-if 1.0.3",
+ "futures-core",
+ "futures-io",
+ "rustix",
+ "signal-hook-registry",
+ "slab",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
+name = "async-std"
+version = "1.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c8e079a4ab67ae52b7403632e4618815d6db36d2a010cfe41b02c1b1578f93b"
+dependencies = [
+ "async-attributes",
+ "async-channel 1.9.0",
+ "async-global-executor",
+ "async-io",
+ "async-lock 3.4.1",
+ "async-process",
+ "crossbeam-utils",
+ "futures-channel",
+ "futures-core",
+ "futures-io",
+ "futures-lite 2.6.1",
+ "gloo-timers 0.3.0",
+ "kv-log-macro",
+ "log",
+ "memchr",
+ "once_cell",
+ "pin-project-lite",
+ "pin-utils",
+ "slab",
+ "wasm-bindgen-futures",
 ]
 
 [[package]]
@@ -616,6 +763,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55248b47b0caf0546f7988906588779981c43bb1bc9d0c44087278f80cdb44ba"
 
 [[package]]
+name = "basic-cookies"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67bd8fd42c16bdb08688243dc5f0cc117a3ca9efeeaba3a345a18a6159ad96f7"
+dependencies = [
+ "lalrpop",
+ "lalrpop-util",
+ "regex",
+]
+
+[[package]]
 name = "bevy"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -679,7 +837,7 @@ checksum = "935984568f75867dd7357133b06f4b1502cd2be55e4642d483ce597e46e63bff"
 dependencies = [
  "async-broadcast",
  "async-fs",
- "async-lock",
+ "async-lock 2.8.0",
  "bevy_app",
  "bevy_asset_macros",
  "bevy_ecs",
@@ -1392,7 +1550,7 @@ dependencies = [
  "bitflags 2.9.4",
  "cexpr",
  "clang-sys",
- "itertools",
+ "itertools 0.13.0",
  "proc-macro2",
  "quote",
  "regex",
@@ -1992,6 +2150,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
+name = "crunchy"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
+
+[[package]]
 name = "crypto-bigint"
 version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2129,6 +2293,27 @@ dependencies = [
  "const-oid",
  "crypto-common",
  "subtle",
+]
+
+[[package]]
+name = "dirs-next"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b98cf8ebf19c3d1b223e151f99a4f9f0690dca41414773390fc824184ac833e1"
+dependencies = [
+ "cfg-if 1.0.3",
+ "dirs-sys-next",
+]
+
+[[package]]
+name = "dirs-sys-next"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ebda144c4fe02d1f7ea1a7d9641b6fc6b580adcfa024ae48797ecdeb6825b4d"
+dependencies = [
+ "libc",
+ "redox_users",
+ "winapi",
 ]
 
 [[package]]
@@ -2270,6 +2455,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "edd0f118536f44f5ccd48bcb8b111bdc3de888b58c74639dfb034a357d0f206d"
 
 [[package]]
+name = "ena"
+version = "0.14.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d248bdd43ce613d87415282f69b9bb99d947d290b10962dd6c56233312c2ad5"
+dependencies = [
+ "log",
+]
+
+[[package]]
 name = "encase"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2318,7 +2512,7 @@ dependencies = [
  "bevy",
  "bevy_rapier3d",
  "futures-lite 2.6.1",
- "gloo-timers",
+ "gloo-timers 0.2.6",
  "log",
  "logtest",
  "net",
@@ -2826,6 +3020,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "gloo-timers"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbb143cf96099802033e0d4f4963b19fd2e0b728bcf076cd9cf7f6634f092994"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "glow"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3073,6 +3279,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
+name = "hermit-abi"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
+
+[[package]]
 name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3205,6 +3417,34 @@ name = "httpdate"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
+name = "httpmock"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08ec9586ee0910472dec1a1f0f8acf52f0fdde93aea74d70d4a3107b4be0fd5b"
+dependencies = [
+ "assert-json-diff",
+ "async-object-pool",
+ "async-std",
+ "async-trait",
+ "base64 0.21.7",
+ "basic-cookies",
+ "crossbeam-utils",
+ "form_urlencoded",
+ "futures-util",
+ "hyper 0.14.32",
+ "lazy_static",
+ "levenshtein",
+ "log",
+ "regex",
+ "serde",
+ "serde_json",
+ "serde_regex",
+ "similar",
+ "tokio",
+ "url",
+]
 
 [[package]]
 name = "hyper"
@@ -3572,6 +3812,15 @@ checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
 
 [[package]]
 name = "itertools"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1c173a5686ce8bfa551b3563d0c2170bf24ca44da99c7ca4bfdab5418c3fe57"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
@@ -3692,6 +3941,46 @@ dependencies = [
 ]
 
 [[package]]
+name = "kv-log-macro"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0de8b303297635ad57c9f5059fd9cee7a47f8e8daa09df0fcd07dd39fb22977f"
+dependencies = [
+ "log",
+]
+
+[[package]]
+name = "lalrpop"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55cb077ad656299f160924eb2912aa147d7339ea7d69e1b5517326fdcec3c1ca"
+dependencies = [
+ "ascii-canvas",
+ "bit-set",
+ "ena",
+ "itertools 0.11.0",
+ "lalrpop-util",
+ "petgraph",
+ "pico-args",
+ "regex",
+ "regex-syntax 0.8.6",
+ "string_cache",
+ "term",
+ "tiny-keccak",
+ "unicode-xid",
+ "walkdir",
+]
+
+[[package]]
+name = "lalrpop-util"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "507460a910eb7b32ee961886ff48539633b788a36b65692b95f225b844c82553"
+dependencies = [
+ "regex-automata",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3738,6 +4027,12 @@ dependencies = [
  "tokio-native-tls",
  "url",
 ]
+
+[[package]]
+name = "levenshtein"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db13adb97ab515a3691f56e4dbab09283d0b86cb45abd991d8634a9d6f501760"
 
 [[package]]
 name = "lewton"
@@ -4167,6 +4462,12 @@ dependencies = [
  "web-sys",
  "webrtc",
 ]
+
+[[package]]
+name = "new_debug_unreachable"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
 
 [[package]]
 name = "nix"
@@ -4758,12 +5059,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "phf_shared"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67eabc2ef2a60eb7faa00097bd1ffdb5bd28e62bf39990626a582201b7a754e5"
+dependencies = [
+ "siphasher",
+]
+
+[[package]]
 name = "physics"
 version = "0.1.0"
 dependencies = [
  "bevy",
  "bevy_rapier3d",
 ]
+
+[[package]]
+name = "pico-args"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5be167a7af36ee22fe3115051bc51f6e6c7054c9348e28deb4f49bd6f705a315"
 
 [[package]]
 name = "pin-project-lite"
@@ -4840,6 +5156,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "polling"
+version = "3.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5bd19146350fe804f7cb2669c851c03d69da628803dab0d98018142aaa5d829"
+dependencies = [
+ "cfg-if 1.0.3",
+ "concurrent-queue",
+ "hermit-abi",
+ "pin-project-lite",
+ "rustix",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
 name = "polyval"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4911,6 +5241,12 @@ checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
 dependencies = [
  "zerocopy",
 ]
+
+[[package]]
+name = "precomputed-hash"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "925383efa346730478fb4838dbe9137d2a47675ad789c546d150a6e1dd4ab31c"
 
 [[package]]
 name = "primeorder"
@@ -5116,6 +5452,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5407465600fb0548f1442edf71dd20683c6ed326200ace4b1ef0763521bb3b77"
 dependencies = [
  "bitflags 2.9.4",
+]
+
+[[package]]
+name = "redox_users"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43"
+dependencies = [
+ "getrandom 0.2.16",
+ "libredox",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -5608,6 +5955,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_regex"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8136f1a4ea815d7eac4101cfd0b16dc0cb5e1fe1b8609dfd728058656b7badf"
+dependencies = [
+ "regex",
+ "serde",
+]
+
+[[package]]
 name = "serde_spanned"
 version = "0.6.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5762,6 +6119,18 @@ name = "simd-adler32"
 version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d66dc143e6b11c1eddc06d5c423cfc97062865baf299914ab64caa38182078fe"
+
+[[package]]
+name = "similar"
+version = "2.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbbb5d9659141646ae647b42fe094daf6c6192d1620870b449d9557f748b2daa"
+
+[[package]]
+name = "siphasher"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56199f7ddabf13fe5074ce809e7d3f42b42ae711800501b5b16ea82ad029c39d"
 
 [[package]]
 name = "slab"
@@ -6090,6 +6459,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
+name = "string_cache"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf776ba3fa74f83bf4b63c3dcbbf82173db2632ed8452cb2d891d33f459de70f"
+dependencies = [
+ "new_debug_unreachable",
+ "parking_lot",
+ "phf_shared",
+ "precomputed-hash",
+]
+
+[[package]]
 name = "stringprep"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6264,6 +6645,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "term"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c59df8ac95d96ff9bede18eb7300b0fda5e5d8d90960e76f8e14ae765eedbf1f"
+dependencies = [
+ "dirs-next",
+ "rustversion",
+ "winapi",
+]
+
+[[package]]
 name = "termcolor"
 version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6369,6 +6761,15 @@ checksum = "30cfb0125f12d9c277f35663a0a33f8c30190f4e4574868a330595412d34ebf3"
 dependencies = [
  "num-conv",
  "time-core",
+]
+
+[[package]]
+name = "tiny-keccak"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c9d3793400a45f954c52e73d068316d76b6f4e36977e3fcebb13a2721e80237"
+dependencies = [
+ "crunchy",
 ]
 
 [[package]]

--- a/crates/analytics/Cargo.toml
+++ b/crates/analytics/Cargo.toml
@@ -4,9 +4,18 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
-prometheus = "0.13"
-opentelemetry = { version = "0.22", features = ["metrics"] }
-reqwest = { version = "0.11", features = ["json", "rustls-tls"] }
+prometheus = { version = "0.13", optional = true }
+opentelemetry = { version = "0.22", features = ["metrics"], optional = true }
+reqwest = { version = "0.11", features = ["json", "rustls-tls"], optional = true }
 serde = { version = "1", features = ["derive"] }
-serde_json = "1"
-tokio = { version = "1", features = ["rt", "macros"] }
+serde_json = { version = "1", optional = true }
+tokio = { version = "1", features = ["rt", "macros"], optional = true }
+
+[features]
+default = ["posthog", "otlp", "prometheus"]
+posthog = ["reqwest", "serde_json", "tokio"]
+otlp = ["opentelemetry"]
+prometheus = ["dep:prometheus"]
+
+[dev-dependencies]
+httpmock = "0.7"

--- a/crates/analytics/src/lib.rs
+++ b/crates/analytics/src/lib.rs
@@ -1,12 +1,31 @@
+use std::sync::{Arc, Mutex};
+
+#[cfg(feature = "otlp")]
 use opentelemetry::{global, metrics::Counter, KeyValue};
+#[cfg(feature = "otlp")]
+use std::sync::atomic::{AtomicU64, Ordering};
+#[cfg(feature = "prometheus")]
 use prometheus::{opts, IntCounterVec};
+#[cfg(feature = "posthog")]
 use reqwest::Client;
 use serde::Serialize;
 
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
 pub enum Event {
     WsConnected,
     MailTestQueued,
+    // Gameplay
+    PlayerJoined,
+    PlayerJumped,
+    PlayerDied,
+    // Economy
+    ItemPurchased,
+    CurrencyEarned,
+    CurrencySpent,
+    // Performance
+    FrameDropped,
+    HighLatency,
+    TickOverrun,
 }
 
 impl Event {
@@ -14,64 +33,165 @@ impl Event {
         match self {
             Event::WsConnected => "ws_connected",
             Event::MailTestQueued => "mail_test_queued",
+            Event::PlayerJoined => "player_joined",
+            Event::PlayerJumped => "player_jumped",
+            Event::PlayerDied => "player_died",
+            Event::ItemPurchased => "item_purchased",
+            Event::CurrencyEarned => "currency_earned",
+            Event::CurrencySpent => "currency_spent",
+            Event::FrameDropped => "frame_dropped",
+            Event::HighLatency => "high_latency",
+            Event::TickOverrun => "tick_overrun",
         }
     }
 }
 
 #[derive(Clone)]
 pub struct Analytics {
+    store: Arc<Mutex<Vec<Event>>>,
+    #[cfg(feature = "prometheus")]
     counter: IntCounterVec,
-    posthog: Option<(Client, String)>,
-    otel: Option<Counter<u64>>,
+    #[cfg(feature = "posthog")]
+    posthog: Option<(Client, String, String)>,
+    #[cfg(feature = "otlp")]
+    otel: Option<(Counter<u64>, Arc<AtomicU64>)>,
 }
 
 impl Analytics {
     pub fn new(posthog_key: Option<String>, enable_otel: bool) -> Self {
-        let counter = IntCounterVec::new(
-            opts!("analytics_events_total", "count of analytics events"),
-            &["event"],
-        )
-        .expect("metric can be created");
-        let _ = prometheus::default_registry().register(Box::new(counter.clone()));
+        let store = Arc::new(Mutex::new(Vec::new()));
 
-        let posthog = posthog_key.map(|key| (Client::new(), key));
+        #[cfg(feature = "prometheus")]
+        let counter = {
+            let c = IntCounterVec::new(
+                opts!("analytics_events_total", "count of analytics events"),
+                &["event"],
+            )
+            .expect("metric can be created");
+            let _ = prometheus::default_registry().register(Box::new(c.clone()));
+            c
+        };
 
+        #[cfg(feature = "posthog")]
+        let posthog = posthog_key.map(|key| {
+            let endpoint = std::env::var("POSTHOG_ENDPOINT")
+                .unwrap_or_else(|_| "https://app.posthog.com/capture/".to_string());
+            (Client::new(), key, endpoint)
+        });
+        #[cfg(not(feature = "posthog"))]
+        let _ = posthog_key;
+
+        #[cfg(feature = "otlp")]
         let otel = if enable_otel {
             let meter = global::meter("analytics");
-            Some(meter.u64_counter("analytics_events").init())
+            let counter = meter.u64_counter("analytics_events").init();
+            let calls = Arc::new(AtomicU64::new(0));
+            Some((counter, calls))
         } else {
             None
         };
+        #[cfg(not(feature = "otlp"))]
+        let _ = enable_otel;
 
         Self {
+            store,
+            #[cfg(feature = "prometheus")]
             counter,
+            #[cfg(feature = "posthog")]
             posthog,
+            #[cfg(feature = "otlp")]
             otel,
         }
     }
 
     pub fn dispatch(&self, event: Event) {
+        self.store.lock().unwrap().push(event.clone());
         let name = event.name();
+
+        #[cfg(feature = "prometheus")]
         self.counter.with_label_values(&[name]).inc();
 
-        if let Some((client, key)) = &self.posthog {
+        #[cfg(feature = "posthog")]
+        if let Some((client, key, endpoint)) = &self.posthog {
             let payload = serde_json::json!({
                 "api_key": key,
                 "event": name,
-                "distinct_id": "server"
+                "distinct_id": "server",
             });
             let client = client.clone();
+            let endpoint = endpoint.clone();
             tokio::spawn(async move {
-                let _ = client
-                    .post("https://app.posthog.com/capture/")
-                    .json(&payload)
-                    .send()
-                    .await;
+                let _ = client.post(endpoint).json(&payload).send().await;
             });
         }
 
-        if let Some(counter) = &self.otel {
+        #[cfg(feature = "otlp")]
+        if let Some((counter, calls)) = &self.otel {
             counter.add(1, &[KeyValue::new("event", name)]);
+            calls.fetch_add(1, Ordering::Relaxed);
         }
     }
+
+    pub fn events(&self) -> Vec<Event> {
+        self.store.lock().unwrap().clone()
+    }
+
+    #[cfg(feature = "prometheus")]
+    pub fn counter_value(&self, name: &str) -> u64 {
+        self.counter.with_label_values(&[name]).get()
+    }
+
+    #[cfg(feature = "otlp")]
+    pub fn otlp_count(&self) -> u64 {
+        self
+            .otel
+            .as_ref()
+            .map(|(_, c)| c.load(Ordering::Relaxed))
+            .unwrap_or(0)
+    }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn store_and_prometheus() {
+        let analytics = Analytics::new(None, false);
+        analytics.dispatch(Event::PlayerJoined);
+        assert_eq!(analytics.events(), vec![Event::PlayerJoined]);
+        assert_eq!(analytics.counter_value("player_joined"), 1);
+    }
+
+    #[cfg(feature = "posthog")]
+    #[tokio::test]
+    async fn posthog_sink() {
+        use httpmock::{Method::POST, MockServer};
+        use std::time::Duration;
+
+        let server = MockServer::start();
+        let mock = server.mock(|when, then| {
+            when.method(POST).path("/capture/");
+            then.status(200);
+        });
+
+        unsafe {
+            std::env::set_var("POSTHOG_ENDPOINT", server.url("/capture/"));
+        }
+
+        let analytics = Analytics::new(Some("test_key".into()), false);
+        analytics.dispatch(Event::PlayerJoined);
+
+        tokio::time::sleep(Duration::from_millis(50)).await;
+        mock.assert();
+    }
+
+    #[cfg(feature = "otlp")]
+    #[test]
+    fn otlp_counter() {
+        let analytics = Analytics::new(None, true);
+        analytics.dispatch(Event::PlayerJoined);
+        assert_eq!(analytics.otlp_count(), 1);
+    }
+}
+

--- a/docs/Analytics.md
+++ b/docs/Analytics.md
@@ -33,3 +33,23 @@ track_event("player_jump", &["height", "2.3"]);
 ```
 
 Attach `AnalyticsPlugin` to the server to automatically forward events.
+
+## Events
+
+### Gameplay
+
+- `player_joined` - emitted when a player connects
+- `player_jumped` - emitted when a player jumps
+- `player_died` - emitted when a player dies
+
+### Economy
+
+- `item_purchased` - player purchases an item
+- `currency_earned` - player gains currency
+- `currency_spent` - player spends currency
+
+### Performance
+
+- `frame_dropped` - a frame took too long to render
+- `high_latency` - network latency exceeded threshold
+- `tick_overrun` - server tick exceeded budget


### PR DESCRIPTION
## Summary
- track gameplay, economy, and performance events
- support PostHog, OTLP, and Prometheus sinks behind features
- locally persist dispatched events and test sink wiring

## Testing
- `cargo test -p analytics`
- `cargo test --workspace --exclude xtask` *(fails: The system library `alsa` required by crate `alsa-sys` was not found)*
- `npm run prettier`


------
https://chatgpt.com/codex/tasks/task_e_68bda57200f08323a785e9a63ff82e88