### PR TITLE
Verify leaderboard runs via replay

### DIFF
--- a/crates/analytics/src/lib.rs
+++ b/crates/analytics/src/lib.rs
@@ -7,6 +7,7 @@ use serde::Serialize;
 pub enum Event {
     WsConnected,
     MailTestQueued,
+    RunVerificationFailed,
 }
 
 impl Event {
@@ -14,6 +15,7 @@ impl Event {
         match self {
             Event::WsConnected => "ws_connected",
             Event::MailTestQueued => "mail_test_queued",
+            Event::RunVerificationFailed => "run_verification_failed",
         }
     }
 }


### PR DESCRIPTION
## Summary
- replay leaderboard submissions headlessly and validate scores before recording
- add analytics event for failed run verification
- broadcast leaderboard window in websocket updates

## Testing
- `npm run prettier`
- `cargo test -p analytics`
- `cargo test -p leaderboard`
- `cargo test -p server` *(fails: bevy_ecs missing for editor crate)*

------
https://chatgpt.com/codex/tasks/task_e_68bda57a5c388323b421413cf8466dbe