### PR TITLE
feat(editor): persist levels in browser storage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1708,6 +1708,7 @@ dependencies = [
  "physics",
  "render",
  "wasm-bindgen",
+ "wasm-bindgen-test",
  "wee_alloc",
 ]
 
@@ -2206,6 +2207,7 @@ dependencies = [
  "toml",
  "wasm-bindgen",
  "wasm-bindgen-futures",
+ "web-sys",
 ]
 
 [[package]]

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -43,3 +43,6 @@ webgl2 = ["render/webgl2"]
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 wee_alloc = { version = "0.4" }
 wasm-bindgen = "0.2"
+
+[dev-dependencies]
+wasm-bindgen-test = "0.3"

--- a/client/tests/storage.rs
+++ b/client/tests/storage.rs
@@ -1,0 +1,42 @@
+#![cfg(target_arch = "wasm32")]
+
+use editor::{client::EditorClient, level::Level};
+use wasm_bindgen_test::*;
+
+wasm_bindgen_test_configure!(run_in_browser);
+
+#[wasm_bindgen_test]
+async fn save_and_load_level() {
+    let client = EditorClient::new();
+    let level = Level::new("t1", "Test Level");
+    client.store_level_locally(&level).await.unwrap();
+
+    let loaded = client
+        .load_level_locally("t1")
+        .await
+        .unwrap()
+        .expect("level loaded");
+    assert_eq!(loaded.name, "Test Level");
+}
+
+#[wasm_bindgen_test]
+async fn load_missing_level_returns_none() {
+    let client = EditorClient::new();
+    assert!(client.load_level_locally("missing").await.unwrap().is_none());
+}
+
+#[wasm_bindgen_test]
+async fn upgrade_does_not_clear_data() {
+    let client = EditorClient::new();
+    let level = Level::new("up", "Upgrade Test");
+    client.store_level_locally(&level).await.unwrap();
+    // Saving again should succeed and preserve data (upgrade path).
+    client.store_level_locally(&level).await.unwrap();
+    let loaded = client
+        .load_level_locally("up")
+        .await
+        .unwrap()
+        .expect("level");
+    assert_eq!(loaded.name, "Upgrade Test");
+}
+

--- a/crates/editor/Cargo.toml
+++ b/crates/editor/Cargo.toml
@@ -9,11 +9,29 @@ serde = { version = "1", features = ["derive"] }
 toml = "0.8"
 platform-api = { path = "../platform-api" }
 serde_json = "1"
+bevy_ecs = { version = "0.12", default-features = false }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 wasm-bindgen = "0.2"
 wasm-bindgen-futures = "0.4"
-bevy_ecs = { version = "0.12", default-features = false }
+web-sys = { version = "0.3", features = [
+    "Window",
+    "Navigator",
+    "StorageManager",
+    "FileSystemDirectoryHandle",
+    "FileSystemFileHandle",
+    "FileSystemWritableFileStream",
+    "FileSystemGetFileOptions",
+    "File",
+    "IdbFactory",
+    "IdbOpenDbRequest",
+    "IdbDatabase",
+    "IdbTransaction",
+    "IdbObjectStore",
+    "IdbRequest",
+    "IdbTransactionMode",
+    "IdbVersionChangeEvent",
+] }
 
 [dev-dependencies]
 

--- a/crates/editor/src/client.rs
+++ b/crates/editor/src/client.rs
@@ -1,17 +1,14 @@
 use crate::level::Level;
 
 #[cfg(target_arch = "wasm32")]
-use wasm_bindgen::prelude::*;
+use wasm_bindgen::{prelude::*, JsCast};
 #[cfg(target_arch = "wasm32")]
-use wasm_bindgen_futures::spawn_local;
+use wasm_bindgen_futures::JsFuture;
 #[cfg(target_arch = "wasm32")]
-#[wasm_bindgen]
-extern "C" {
-    #[wasm_bindgen(js_name = storeLevel)]
-    async fn store_level(id: &str, data: &str);
-    #[wasm_bindgen(js_name = loadLevel)]
-    async fn load_level(id: &str) -> JsValue;
-}
+use web_sys::{
+    FileSystemDirectoryHandle, FileSystemFileHandle, FileSystemGetFileOptions,
+    FileSystemWritableFileStream, IdbDatabase, IdbTransactionMode, StorageManager,
+};
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum EditorMode {
@@ -27,46 +24,149 @@ pub struct EditorClient {
 }
 
 impl EditorClient {
-    pub fn new() -> Self {
-        Self { mode: EditorMode::FirstPerson }
-    }
+    pub fn new() -> Self { Self { mode: EditorMode::FirstPerson } }
 
-    pub fn set_mode(&mut self, mode: EditorMode) {
-        self.mode = mode;
-    }
+    pub fn set_mode(&mut self, mode: EditorMode) { self.mode = mode; }
 
-    /// Store level data using the browser's OPFS/IndexedDB.
-    ///
-    /// This is a placeholder implementation. The actual
-    /// Web APIs would be invoked from WASM.
-    #[allow(unused_variables)]
-    pub fn store_level_locally(&self, level: &Level) {
+    /// Persist the level locally using OPFS or IndexedDB.
+    pub async fn store_level_locally(&self, level: &Level) -> Result<(), String> {
         #[cfg(target_arch = "wasm32")]
         {
-            let id = level.id.clone();
-            let data = serde_json::to_string(level).expect("serialize level");
-            spawn_local(async move {
-                let _ = store_level(&id, &data).await;
-            });
+            let data = serde_json::to_string(level).map_err(|e| e.to_string())?;
+            save_level(&level.id, &data)
+                .await
+                .map_err(|e| format!("{e:?}"))
+        }
+        #[cfg(not(target_arch = "wasm32"))]
+        {
+            let _ = level;
+            Ok(())
         }
     }
 
-    #[allow(dead_code)]
-    #[allow(unused_variables)]
-    pub async fn load_level_locally(&self, id: &str) -> Option<Level> {
+    /// Load a previously stored level.
+    pub async fn load_level_locally(&self, id: &str) -> Result<Option<Level>, String> {
         #[cfg(target_arch = "wasm32")]
         {
-            let data = load_level(id).await;
-            if data.is_null() || data.is_undefined() {
-                return None;
+            match load_level(id).await {
+                Ok(Some(data)) => serde_json::from_str(&data)
+                    .map(Some)
+                    .map_err(|e| e.to_string()),
+                Ok(None) => Ok(None),
+                Err(e) => Err(format!("{e:?}")),
             }
-            let s = data.as_string()?;
-            return serde_json::from_str(&s).ok();
         }
         #[cfg(not(target_arch = "wasm32"))]
         {
             let _ = id;
-            None
+            Ok(None)
         }
     }
 }
+
+// --- wasm helpers ---
+
+#[cfg(target_arch = "wasm32")]
+const DB_NAME: &str = "editor-levels";
+#[cfg(target_arch = "wasm32")]
+const STORE_NAME: &str = "levels";
+#[cfg(target_arch = "wasm32")]
+const DB_VERSION: u32 = 1;
+
+#[cfg(target_arch = "wasm32")]
+async fn save_level(id: &str, data: &str) -> Result<(), JsValue> {
+    if save_opfs(id, data).await.is_err() {
+        save_idb(id, data).await?
+    }
+    Ok(())
+}
+
+#[cfg(target_arch = "wasm32")]
+async fn load_level(id: &str) -> Result<Option<String>, JsValue> {
+    if let Ok(Some(data)) = load_opfs(id).await {
+        return Ok(Some(data));
+    }
+    load_idb(id).await
+}
+
+#[cfg(target_arch = "wasm32")]
+async fn save_opfs(id: &str, data: &str) -> Result<(), JsValue> {
+    let window = web_sys::window().ok_or_else(|| JsValue::from_str("no window"))?;
+    let navigator = window.navigator();
+    let storage: StorageManager = navigator
+        .storage()
+        .ok_or_else(|| JsValue::from_str("no storage"))?;
+    let dir_js = JsFuture::from(storage.get_directory()).await?;
+    let dir: FileSystemDirectoryHandle = dir_js.dyn_into()?;
+    let mut opts = FileSystemGetFileOptions::new();
+    opts.create(true);
+    let file_js = JsFuture::from(dir.get_file_handle_with_options(id, &opts)).await?;
+    let file: FileSystemFileHandle = file_js.dyn_into()?;
+    let writable_js = JsFuture::from(file.create_writable()).await?;
+    let writable: FileSystemWritableFileStream = writable_js.dyn_into()?;
+    JsFuture::from(writable.write_with_str(data)).await?;
+    JsFuture::from(writable.close()).await?;
+    Ok(())
+}
+
+#[cfg(target_arch = "wasm32")]
+async fn load_opfs(id: &str) -> Result<Option<String>, JsValue> {
+    let window = web_sys::window().ok_or_else(|| JsValue::from_str("no window"))?;
+    let navigator = window.navigator();
+    let storage: StorageManager = navigator
+        .storage()
+        .ok_or_else(|| JsValue::from_str("no storage"))?;
+    let dir_js = JsFuture::from(storage.get_directory()).await?;
+    let dir: FileSystemDirectoryHandle = dir_js.dyn_into()?;
+    let file_js = JsFuture::from(dir.get_file_handle(id)).await;
+    let file_handle = match file_js {
+        Ok(v) => v.dyn_into::<FileSystemFileHandle>()?,
+        Err(_) => return Ok(None),
+    };
+    let file_js = JsFuture::from(file_handle.get_file()).await?;
+    let file: web_sys::File = file_js.dyn_into()?;
+    let text_js = JsFuture::from(file.text()).await?;
+    Ok(text_js.as_string())
+}
+
+#[cfg(target_arch = "wasm32")]
+async fn open_db() -> Result<IdbDatabase, JsValue> {
+    let window = web_sys::window().ok_or_else(|| JsValue::from_str("no window"))?;
+    let factory = window
+        .indexed_db()?
+        .ok_or_else(|| JsValue::from_str("no indexeddb"))?;
+    let open = factory.open_with_u32(DB_NAME, DB_VERSION)?;
+    let on_upgrade = Closure::once_into_js(Box::new(move |_evt: web_sys::IdbVersionChangeEvent| {
+        let db = open.result().unwrap().dyn_into::<IdbDatabase>().unwrap();
+        let _ = db.create_object_store(STORE_NAME);
+    }));
+    open.set_onupgradeneeded(Some(on_upgrade.as_ref().unchecked_ref()));
+    on_upgrade.forget();
+    let db_js = JsFuture::from(open).await?;
+    db_js.dyn_into()
+}
+
+#[cfg(target_arch = "wasm32")]
+async fn save_idb(id: &str, data: &str) -> Result<(), JsValue> {
+    let db = open_db().await?;
+    let tx = db.transaction_with_str_and_mode(STORE_NAME, IdbTransactionMode::Readwrite)?;
+    let store = tx.object_store(STORE_NAME)?;
+    let req = store.put_with_key(&JsValue::from_str(data), &JsValue::from_str(id))?;
+    JsFuture::from(req).await?;
+    Ok(())
+}
+
+#[cfg(target_arch = "wasm32")]
+async fn load_idb(id: &str) -> Result<Option<String>, JsValue> {
+    let db = open_db().await?;
+    let tx = db.transaction_with_str_and_mode(STORE_NAME, IdbTransactionMode::Readonly)?;
+    let store = tx.object_store(STORE_NAME)?;
+    let req = store.get(&JsValue::from_str(id))?;
+    let val = JsFuture::from(req).await?;
+    if val.is_undefined() {
+        Ok(None)
+    } else {
+        Ok(val.as_string())
+    }
+}
+


### PR DESCRIPTION
## Summary
- store editor `Level` data in OPFS with IndexedDB fallback
- add async save/load APIs with error reporting
- cover save/load/upgrade flows with wasm-bindgen browser tests

## Testing
- `npm run prettier`
- `cargo test -p editor`
- `cargo test -p client` *(fails to run wasm tests in this environment)*


------
https://chatgpt.com/codex/tasks/task_e_68bda58e0ba483239b812b7a45419583