### PR TITLE
Abort email cleanup on drop

### DIFF
--- a/server/src/email.rs
+++ b/server/src/email.rs
@@ -2,7 +2,8 @@
 //!
 //! A background task periodically purges expired entries from the rate-limit
 //! map. The task runs on the Tokio runtime and its [`JoinHandle`] is stored so
-//! it can be aborted during shutdown if necessary.
+//! it can be aborted during shutdown if necessary. The cleanup task is
+//! terminated when [`EmailService`] is dropped.
 
 use clap::{Args, ValueEnum};
 use lettre::address::AddressError;
@@ -333,6 +334,13 @@ impl EmailService {
 
     pub fn abort_cleanup(&self) {
         self.cleanup.abort();
+    }
+}
+
+impl Drop for EmailService {
+    fn drop(&mut self) {
+        // Terminate the cleanup task when the service is dropped.
+        self.abort_cleanup();
     }
 }
 


### PR DESCRIPTION
## Summary
- abort email cleanup task when `EmailService` is dropped
- document that the cleanup task is terminated on drop

## Testing
- `npm run prettier`
- `cargo test -p server` *(fails: duplicate key `payments` in table `dependencies`)*

------
https://chatgpt.com/codex/tasks/task_e_68bdb0e84a548323886fa3f43184d323