### PR TITLE
Remove duplicate PurchaseInitiated event

### DIFF
--- a/crates/analytics/src/lib.rs
+++ b/crates/analytics/src/lib.rs
@@ -14,7 +14,6 @@ use serde::Serialize;
 pub enum Event {
     WsConnected,
     MailTestQueued,
-    PurchaseInitiated,
     PurchaseCompleted,
     EntitlementChecked,
     RunVerificationFailed,
@@ -43,7 +42,6 @@ impl Event {
         match self {
             Event::WsConnected => "ws_connected",
             Event::MailTestQueued => "mail_test_queued",
-            Event::PurchaseInitiated => "purchase_initiated",
             Event::PurchaseCompleted => "purchase_completed",
             Event::EntitlementChecked => "entitlement_checked",
             Event::RunVerificationFailed => "run_verification_failed",


### PR DESCRIPTION
## Summary
- deduplicate `PurchaseInitiated` event variant
- update `Event::name` mapping

## Testing
- `npm run prettier`
- `cargo test` *(fails: duplicate key `payments` in server/Cargo.toml)*

------
https://chatgpt.com/codex/tasks/task_e_68bdb0bea4108323a790d7f120ee4084