### PR TITLE
Gate analytics store test behind prometheus feature

### DIFF
--- a/crates/analytics/src/lib.rs
+++ b/crates/analytics/src/lib.rs
@@ -171,12 +171,21 @@ impl Analytics {
 mod tests {
     use super::*;
 
+    #[cfg(feature = "prometheus")]
     #[test]
     fn store_and_prometheus() {
         let analytics = Analytics::new(None, false);
         analytics.dispatch(Event::PlayerJoined);
         assert_eq!(analytics.events(), vec![Event::PlayerJoined]);
         assert_eq!(analytics.counter_value("player_joined"), 1);
+    }
+
+    #[cfg(not(feature = "prometheus"))]
+    #[test]
+    fn store() {
+        let analytics = Analytics::new(None, false);
+        analytics.dispatch(Event::PlayerJoined);
+        assert_eq!(analytics.events(), vec![Event::PlayerJoined]);
     }
 
     #[cfg(feature = "posthog")]


### PR DESCRIPTION
## Summary
- wrap `store_and_prometheus` test with `cfg(feature = "prometheus")`
- add minimal `store` test when `prometheus` is disabled

## Testing
- `npm run prettier`
- `cargo test -p analytics` *(fails: duplicate key `payments` in server/Cargo.toml)*

------
https://chatgpt.com/codex/tasks/task_e_68bdb1adc2388323934c5e3aa8713239