### PR TITLE
Initialize entitlements path and load store

### DIFF
--- a/crates/leaderboard/src/lib.rs
+++ b/crates/leaderboard/src/lib.rs
@@ -72,13 +72,14 @@ impl LeaderboardService {
 
     pub async fn verify_run(&self, run_id: Uuid) -> bool {
         let mut scores = self.scores.lock().unwrap();
+        let mut found = false;
         for list in scores.values_mut() {
             if let Some(score) = list.iter_mut().find(|s| s.run_id == run_id) {
                 score.verified = true;
-                return true;
+                found = true;
             }
         }
-        false
+        found
     }
 }
 

--- a/server/src/leaderboard.rs
+++ b/server/src/leaderboard.rs
@@ -179,11 +179,12 @@ mod tests {
         email::{EmailService, SmtpConfig},
         room,
     };
-    use ::leaderboard::LeaderboardWindow;
     use ::payments::{Catalog, EntitlementStore, Sku, StripeClient};
     use analytics::Analytics;
     use axum::Json;
     use axum::extract::{Path, State};
+    use leaderboard::models::LeaderboardWindow;
+    use std::path::PathBuf;
 
     #[tokio::test]
     async fn post_run_rejects_malformed_base64() {
@@ -206,6 +207,7 @@ mod tests {
             }]),
             stripe: StripeClient::new(),
             entitlements: EntitlementStore::default(),
+            entitlements_path: PathBuf::new(),
         });
 
         let leaderboard_id = Uuid::new_v4();
@@ -237,6 +239,10 @@ mod tests {
             smtp: cfg,
             analytics: Analytics::new(None, false),
             leaderboard: ::leaderboard::LeaderboardService::default(),
+            catalog: Catalog::new(vec![]),
+            stripe: StripeClient::new(),
+            entitlements: EntitlementStore::default(),
+            entitlements_path: PathBuf::new(),
         });
 
         let leaderboard_id = Uuid::new_v4();
@@ -271,11 +277,15 @@ mod tests {
             smtp: cfg,
             analytics: Analytics::new(None, false),
             leaderboard: ::leaderboard::LeaderboardService::default(),
+            catalog: Catalog::new(vec![]),
+            stripe: StripeClient::new(),
+            entitlements: EntitlementStore::default(),
+            entitlements_path: PathBuf::new(),
         });
 
         let leaderboard_id = Uuid::new_v4();
         let player = Uuid::new_v4();
-        let replay = base64::encode("data");
+        let replay = base64::encode(10i32.to_le_bytes());
         let payload = SubmitRun {
             player_id: player,
             points: 10,

--- a/server/src/tests.rs
+++ b/server/src/tests.rs
@@ -13,8 +13,9 @@ use webrtc::api::media_engine::MediaEngine;
 use webrtc::peer_connection::configuration::RTCConfiguration;
 
 use crate::test_logger::{INIT, LOGGER};
+use ::payments::{Catalog, EntitlementStore, Sku, StripeClient};
 use log::LevelFilter;
-use ::payments::{Catalog, EntitlementStore, StripeClient, Sku};
+use std::path::PathBuf;
 
 #[tokio::test]
 async fn setup_succeeds_without_env_vars() {
@@ -83,9 +84,13 @@ async fn websocket_signaling_completes_handshake() {
         smtp: cfg,
         analytics: Analytics::new(None, false),
         leaderboard: ::leaderboard::LeaderboardService::default(),
-        catalog: Catalog::new(vec![Sku { id: "basic".into(), price_cents: 1000 }]),
+        catalog: Catalog::new(vec![Sku {
+            id: "basic".into(),
+            price_cents: 1000,
+        }]),
         stripe: StripeClient::new(),
         entitlements: EntitlementStore::default(),
+        entitlements_path: PathBuf::new(),
     });
 
     let app = Router::new()
@@ -146,9 +151,13 @@ async fn websocket_logs_unexpected_messages_and_closes() {
         smtp: cfg,
         analytics: Analytics::new(None, false),
         leaderboard: ::leaderboard::LeaderboardService::default(),
-        catalog: Catalog::new(vec![Sku { id: "basic".into(), price_cents: 1000 }]),
+        catalog: Catalog::new(vec![Sku {
+            id: "basic".into(),
+            price_cents: 1000,
+        }]),
         stripe: StripeClient::new(),
         entitlements: EntitlementStore::default(),
+        entitlements_path: PathBuf::new(),
     });
 
     let app = Router::new()
@@ -192,9 +201,13 @@ async fn mail_test_defaults_to_from_address() {
         smtp: cfg.clone(),
         analytics: Analytics::new(None, false),
         leaderboard: ::leaderboard::LeaderboardService::default(),
-        catalog: Catalog::new(vec![Sku { id: "basic".into(), price_cents: 1000 }]),
+        catalog: Catalog::new(vec![Sku {
+            id: "basic".into(),
+            price_cents: 1000,
+        }]),
         stripe: StripeClient::new(),
         entitlements: EntitlementStore::default(),
+        entitlements_path: PathBuf::new(),
     });
 
     assert_eq!(
@@ -226,9 +239,13 @@ async fn mail_test_accepts_user_address_query() {
         smtp: cfg.clone(),
         analytics: Analytics::new(None, false),
         leaderboard: ::leaderboard::LeaderboardService::default(),
-        catalog: Catalog::new(vec![Sku { id: "basic".into(), price_cents: 1000 }]),
+        catalog: Catalog::new(vec![Sku {
+            id: "basic".into(),
+            price_cents: 1000,
+        }]),
         stripe: StripeClient::new(),
         entitlements: EntitlementStore::default(),
+        entitlements_path: PathBuf::new(),
     });
 
     assert_eq!(
@@ -267,9 +284,13 @@ async fn mail_test_accepts_user_address_body() {
         smtp: cfg.clone(),
         analytics: Analytics::new(None, false),
         leaderboard: ::leaderboard::LeaderboardService::default(),
-        catalog: Catalog::new(vec![Sku { id: "basic".into(), price_cents: 1000 }]),
+        catalog: Catalog::new(vec![Sku {
+            id: "basic".into(),
+            price_cents: 1000,
+        }]),
         stripe: StripeClient::new(),
         entitlements: EntitlementStore::default(),
+        entitlements_path: PathBuf::new(),
     });
 
     assert_eq!(
@@ -307,9 +328,13 @@ async fn mail_config_redacts_password() {
         smtp: cfg.clone(),
         analytics: Analytics::new(None, false),
         leaderboard: ::leaderboard::LeaderboardService::default(),
-        catalog: Catalog::new(vec![Sku { id: "basic".into(), price_cents: 1000 }]),
+        catalog: Catalog::new(vec![Sku {
+            id: "basic".into(),
+            price_cents: 1000,
+        }]),
         stripe: StripeClient::new(),
         entitlements: EntitlementStore::default(),
+        entitlements_path: PathBuf::new(),
     });
 
     let Json(redacted) = mail_config_handler(State(state)).await;
@@ -334,9 +359,13 @@ async fn admin_mail_config_route() {
         smtp: cfg,
         analytics: Analytics::new(None, false),
         leaderboard: ::leaderboard::LeaderboardService::default(),
-        catalog: Catalog::new(vec![Sku { id: "basic".into(), price_cents: 1000 }]),
+        catalog: Catalog::new(vec![Sku {
+            id: "basic".into(),
+            price_cents: 1000,
+        }]),
         stripe: StripeClient::new(),
         entitlements: EntitlementStore::default(),
+        entitlements_path: PathBuf::new(),
     });
 
     let app = Router::new()


### PR DESCRIPTION
## Summary
- remove redundant analytics import from server
- load and persist entitlements via `entitlements.json`
- fix leaderboard verification to mark run across all windows

## Testing
- `npm run prettier`
- `cargo test -p server`

------
https://chatgpt.com/codex/tasks/task_e_68bdbbd5c4f483238d1f191c4b371cbc