### PR TITLE
Refactor payments persistence with load and custom errors

### DIFF
--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -3,7 +3,7 @@ use std::{net::SocketAddr, path::PathBuf, sync::Arc};
 use anyhow::{Result, anyhow};
 
 use crate::email::{EmailService, SmtpConfig, StartTls};
-use ::payments::{Catalog, Entitlement, EntitlementList, EntitlementStore, Sku, StripeClient};
+use ::payments::{Catalog, EntitlementList, EntitlementStore, Sku, StripeClient};
 use analytics::{Analytics, Event};
 use axum::{
     Router,
@@ -314,18 +314,10 @@ async fn setup(smtp: SmtpConfig, analytics: Analytics) -> Result<AppState> {
     }]);
     let stripe = StripeClient::new();
     let entitlements_path = PathBuf::from("entitlements.json");
-    let entitlements = match std::fs::read(&entitlements_path) {
-        Ok(data) => {
-            let store = EntitlementStore::default();
-            if let Ok(existing) = serde_json::from_slice::<Vec<Entitlement>>(&data) {
-                for ent in existing {
-                    store.grant(ent.user_id, ent.sku_id);
-                }
-            }
-            store
-        }
-        Err(_) => EntitlementStore::default(),
-    };
+    let entitlements = EntitlementStore::default();
+    if let Err(e) = entitlements.load(&entitlements_path) {
+        log::warn!("failed to load entitlements: {e}");
+    }
     Ok(AppState {
         email,
         rooms,


### PR DESCRIPTION
## Summary
- Add StoreError and load/save methods for EntitlementStore
- Ignore duplicate entitlements on grant and load
- Initialize server entitlements store by loading existing data

## Testing
- `npm run prettier`
- `cargo +nightly test -p payments -p server`

------
https://chatgpt.com/codex/tasks/task_e_68bdc25760b48323b47a18df9e196343