### PR TITLE
Broadcast duck state snapshots

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2366,6 +2366,10 @@ name = "duck_hunt_server"
 version = "0.1.0"
 dependencies = [
  "glam",
+ "net",
+ "postcard",
+ "serde",
+ "tokio",
 ]
 
 [[package]]

--- a/crates/minigames/duck_hunt/Cargo.toml
+++ b/crates/minigames/duck_hunt/Cargo.toml
@@ -7,4 +7,8 @@ edition = "2024"
 path = "server.rs"
 
 [dependencies]
-glam = "0.24"
+glam = { version = "0.24", features = ["serde"] }
+net = { path = "../../net" }
+postcard = { version = "1", features = ["alloc"] }
+serde = { version = "1", features = ["derive"] }
+tokio = { version = "1", features = ["sync"] }


### PR DESCRIPTION
## Summary
- send duck state snapshots to clients
- push duck updates from room tick
- add test for duck spawn and movement

## Testing
- `npm run prettier`
- `cargo test -p duck_hunt_server`
- `cargo test -p server`


------
https://chatgpt.com/codex/tasks/task_e_68bdcb4a24f083239cb30e1bcc343b53