### PR TITLE
Remove unused ModuleManifest import

### DIFF
--- a/client/crates/engine/src/lib.rs
+++ b/client/crates/engine/src/lib.rs
@@ -11,7 +11,7 @@ use gloo_timers::future::TimeoutFuture;
 #[cfg(not(target_arch = "wasm32"))]
 use notify::{RecommendedWatcher, RecursiveMode, Watcher};
 use platform_api::{
-    AppState, CapabilityFlags, GameModule, ModuleContext, ModuleManifest, ModuleMetadata,
+    AppState, CapabilityFlags, GameModule, ModuleContext, ModuleMetadata,
     discover_local_modules,
 };
 #[cfg(not(target_arch = "wasm32"))]


### PR DESCRIPTION
## Summary
- remove unused ModuleManifest import in engine crate

## Testing
- `npm run prettier`
- `cargo check -p engine`


------
https://chatgpt.com/codex/tasks/task_e_68bddaf4f5e88323b5c20062fea6a988