### PR TITLE
Add Duck Hunt client systems and leaderboard integration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2366,11 +2366,15 @@ dependencies = [
 name = "duck_hunt_server"
 version = "0.1.0"
 dependencies = [
+ "chrono",
  "glam",
+ "leaderboard",
  "net",
  "postcard",
  "serde",
+ "tempfile",
  "tokio",
+ "uuid",
 ]
 
 [[package]]

--- a/assets/levels/duck_hunt_range/README.md
+++ b/assets/levels/duck_hunt_range/README.md
@@ -1,0 +1,3 @@
+# Duck Hunt Range Assets
+
+Placeholder assets for the Duck Hunt mini-game. Replace `sky.png` and other files with proper art when available.

--- a/assets/levels/duck_hunt_range/level.toml
+++ b/assets/levels/duck_hunt_range/level.toml
@@ -1,0 +1,2 @@
+name = "duck_hunt_range"
+background = "sky.png"

--- a/client/crates/minigames/duck_hunt/Cargo.toml
+++ b/client/crates/minigames/duck_hunt/Cargo.toml
@@ -4,7 +4,21 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
-bevy = "0.12"
+bevy = { version = "0.12", default-features = false, features = [
+    "bevy_asset",
+    "bevy_winit",
+    "bevy_core_pipeline",
+    "bevy_pbr",
+    "bevy_render",
+    "bevy_sprite",
+    "bevy_text",
+    "bevy_ui",
+    "multi-threaded",
+    "png",
+    "x11",
+    "tonemapping_luts",
+    "default_font",
+] }
 platform-api = { path = "../../../../crates/platform-api" }
 anyhow = "1"
 postcard = { version = "1", features = ["alloc"] }

--- a/crates/minigames/duck_hunt/Cargo.toml
+++ b/crates/minigames/duck_hunt/Cargo.toml
@@ -11,4 +11,10 @@ glam = { version = "0.24", features = ["serde"] }
 net = { path = "../../net" }
 postcard = { version = "1", features = ["alloc"] }
 serde = { version = "1", features = ["derive"] }
-tokio = { version = "1", features = ["sync"] }
+tokio = { version = "1", features = ["sync", "macros", "rt-multi-thread"] }
+leaderboard = { path = "../../leaderboard" }
+uuid = { version = "1", features = ["v4", "serde"] }
+chrono = { version = "0.4", features = ["serde", "clock"] }
+
+[dev-dependencies]
+tempfile = "3"

--- a/docs/DuckHunt.md
+++ b/docs/DuckHunt.md
@@ -26,12 +26,17 @@ shot events with their crosshair position, and the server performs lag
 compensation before validating hits. Successful hits result in score updates
 that are broadcast to all players.
 
+Scores are also submitted to a leaderboard via the `leaderboard` crate. Each
+shot is recorded and saved as a deterministic replay so runs can be
+independently verified.
+
 ## Assets
 
 - Duck sprite sheet with animation frames
 - Background images for sky and ground
 - Sound effects for quacks, shots, and reloading
 - `module.toml` descriptor under `assets/modules/duck_hunt/`
+- Reference level data under `assets/levels/duck_hunt_range/`
 
 ## Lifecycle
 


### PR DESCRIPTION
## Summary
- Add weapon, HUD, and target spawn systems to Duck Hunt client module
- Implement server-side duck advancement, hit validation, and leaderboard submissions with replay support
- Document leaderboard usage and add placeholder assets for the duck hunt range

## Testing
- `npm run prettier`
- `cargo test -p duck_hunt_server`
- `cargo test --manifest-path client/crates/minigames/duck_hunt/Cargo.toml`


------
https://chatgpt.com/codex/tasks/task_e_68bde780c9c48323b3365540684fa61e