### PR TITLE
feat: add interest masks and fixed tick

### DIFF
--- a/client/crates/engine/src/net.rs
+++ b/client/crates/engine/src/net.rs
@@ -45,7 +45,7 @@ pub struct NetClientPlugin;
 impl Plugin for NetClientPlugin {
     fn build(&self, app: &mut App) {
         app.init_resource::<PredictionState>()
-            .add_systems(Update, client_prediction)
-            .add_systems(Update, reconcile_snapshots);
+            .add_systems(FixedUpdate, client_prediction)
+            .add_systems(FixedUpdate, reconcile_snapshots);
     }
 }

--- a/client/src/main.rs
+++ b/client/src/main.rs
@@ -36,6 +36,7 @@ fn main() {
 
     // Initialize the Bevy application
     let mut app = App::new();
+    app.insert_resource(Time::<Fixed>::from_seconds(1.0 / 60.0));
     app.add_plugins(RenderPlugin)
         .add_plugins(PhysicsPlugin)
         .add_plugins(EnginePlugin);

--- a/crates/net/src/message.rs
+++ b/crates/net/src/message.rs
@@ -11,6 +11,15 @@ pub struct InputFrame {
     pub data: Vec<u8>,
 }
 
+/// Message sent from clients to the server.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub enum ClientMessage {
+    /// An input frame for the given simulation step.
+    Input(InputFrame),
+    /// Update the client's interest mask for snapshot filtering.
+    Interest(u64),
+}
+
 /// Full state snapshot from the server.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Event)]
 pub struct Snapshot {


### PR DESCRIPTION
## Summary
- support client interest masks and input messages for WebRTC transport
- process interest updates on server and tick at fixed 60 Hz
- run client prediction and reconciliation on FixedUpdate schedule with 60 Hz time step

## Testing
- `npm run prettier`
- `cargo test` *(fails: The system library `alsa` required by crate `alsa-sys` was not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bdea9a033883239d87a111f8cb55ce