### PR TITLE
feat(payments): add store provider and webhook validation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5117,9 +5117,13 @@ checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 name = "payments"
 version = "0.1.0"
 dependencies = [
+ "async-trait",
  "chrono",
+ "hex",
+ "hmac",
  "serde",
  "serde_json",
+ "sha2",
  "uuid",
 ]
 

--- a/client/crates/engine/src/lib.rs
+++ b/client/crates/engine/src/lib.rs
@@ -138,6 +138,9 @@ pub struct LeaderboardScreen;
 #[derive(Component)]
 pub struct ReplayPedestal;
 
+#[derive(Component)]
+pub struct StorePanel;
+
 const HELP_DOCS: [(&str, &str); 5] = [
     ("Netcode", "docs/netcode.md"),
     ("Modules", "docs/modules.md"),
@@ -226,6 +229,36 @@ pub fn setup_lobby(
         .as_ref()
         .map(|s| s.load("fonts/FiraSans-Bold.ttf"))
         .unwrap_or_default();
+
+    // Basic store panel showcasing purchasable items.
+    commands
+        .spawn((
+            PbrBundle {
+                mesh: pad_mesh.clone(),
+                material: pad_material.clone(),
+                transform: Transform::from_xyz(0.0, 0.5, -2.5),
+                ..default()
+            },
+            Collider::cuboid(0.5, 0.5, 0.5),
+            Sensor,
+            ActiveEvents::COLLISION_EVENTS,
+            StorePanel,
+            LobbyEntity,
+        ))
+        .with_children(|parent| {
+            parent.spawn(Text2dBundle {
+                text: Text::from_section(
+                    "Store",
+                    TextStyle {
+                        font: font.clone(),
+                        font_size: 20.0,
+                        color: Color::WHITE,
+                    },
+                ),
+                transform: Transform::from_xyz(0.0, 0.75, 0.0),
+                ..default()
+            });
+        });
 
     if registry.modules.is_empty() {
         for (i, &(label, url)) in HELP_DOCS.iter().enumerate() {

--- a/crates/payments/Cargo.toml
+++ b/crates/payments/Cargo.toml
@@ -8,3 +8,7 @@ serde = { version = "1", features = ["derive"] }
 uuid = { version = "1", features = ["serde", "v4"] }
 chrono = { version = "0.4", features = ["serde"] }
 serde_json = "1"
+async-trait = "0.1"
+hmac = "0.12"
+sha2 = "0.10"
+hex = "0.4"

--- a/server/src/leaderboard.rs
+++ b/server/src/leaderboard.rs
@@ -196,7 +196,7 @@ mod tests {
                 id: "basic".into(),
                 price_cents: 1000,
             }]),
-            stripe: StripeClient::new(),
+            store: Arc::new(StripeClient::new(String::new())),
             entitlements: EntitlementStore::default(),
             entitlements_path: PathBuf::new(),
         });
@@ -235,7 +235,7 @@ mod tests {
             analytics: Analytics::new(true, None, false),
             leaderboard: leaderboard.clone(),
             catalog: Catalog::new(vec![]),
-            stripe: StripeClient::new(),
+            store: Arc::new(StripeClient::new(String::new())),
             entitlements: EntitlementStore::default(),
             entitlements_path: PathBuf::new(),
         });
@@ -277,7 +277,7 @@ mod tests {
             analytics: Analytics::new(true, None, false),
             leaderboard: leaderboard.clone(),
             catalog: Catalog::new(vec![]),
-            stripe: StripeClient::new(),
+            store: Arc::new(StripeClient::new(String::new())),
             entitlements: EntitlementStore::default(),
             entitlements_path: PathBuf::new(),
         });


### PR DESCRIPTION
## Summary
- add generic StoreProvider trait with Stripe and mock implementations
- validate Stripe webhooks and start checkouts through provider
- show simple in-lobby store panel and persist entitlements

## Testing
- `npm run prettier`
- `cargo test` *(fails: The system library `alsa` required by crate `alsa-sys` was not found)*
- `apt-get install -y libasound2-dev` *(fails: Unable to locate package libasound2-dev)*
- `cargo test -p payments`


------
https://chatgpt.com/codex/tasks/task_e_68bdfa75245c8323966557d707a585e6