### PR TITLE
feat: add bevy engine crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -301,6 +301,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69f7f8c3906b62b754cd5326047894316021dcfe5a194c8ea52bdd94934a3457"
 
 [[package]]
+name = "arena-engine"
+version = "0.1.0"
+dependencies = [
+ "bevy",
+ "bevy_rapier3d",
+ "platform-api",
+]
+
+[[package]]
 name = "arrayref"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ members = [
     "client",
     "crates/net",
     "crates/platform-api",
+    "crates/engine",
     "crates/editor",
     "xtask",
     "crates/minigames/duck_hunt",

--- a/crates/engine/Cargo.toml
+++ b/crates/engine/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "arena-engine"
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]
+bevy = { version = "0.12", default-features = false, features = ["bevy_render", "bevy_core_pipeline", "bevy_pbr", "bevy_text"] }
+bevy_rapier3d = { version = "0.24", default-features = false, features = ["dim3"] }
+platform-api = { path = "../platform-api" }
+
+[features]
+default = []

--- a/crates/engine/src/assets.rs
+++ b/crates/engine/src/assets.rs
@@ -1,0 +1,10 @@
+use bevy::prelude::*;
+
+/// Registers asset loaders such as KTX2/Basis and meshoptimizer.
+pub struct AssetPlugin;
+
+impl Plugin for AssetPlugin {
+    fn build(&self, _app: &mut App) {
+        // TODO: register asset loaders
+    }
+}

--- a/crates/engine/src/camera.rs
+++ b/crates/engine/src/camera.rs
@@ -1,0 +1,17 @@
+use bevy::prelude::*;
+
+/// Basic yaw/pitch camera with adjustable field of view.
+#[derive(Resource, Default)]
+pub struct CameraSettings {
+    pub yaw: f32,
+    pub pitch: f32,
+    pub fov: f32,
+}
+
+pub struct CameraPlugin;
+
+impl Plugin for CameraPlugin {
+    fn build(&self, _app: &mut App) {
+        // TODO: implement camera control systems
+    }
+}

--- a/crates/engine/src/input.rs
+++ b/crates/engine/src/input.rs
@@ -1,0 +1,10 @@
+use bevy::prelude::*;
+
+/// Handles pointer lock, raw mouse input, and gamepad support.
+pub struct InputPlugin;
+
+impl Plugin for InputPlugin {
+    fn build(&self, _app: &mut App) {
+        // TODO: implement input systems
+    }
+}

--- a/crates/engine/src/lib.rs
+++ b/crates/engine/src/lib.rs
@@ -1,0 +1,42 @@
+use bevy::prelude::*;
+use bevy::ecs::schedule::{Schedule, ScheduleLabel};
+
+#[derive(ScheduleLabel, Debug, Clone, PartialEq, Eq, Hash)]
+pub struct Network;
+
+pub mod input;
+pub mod camera;
+pub mod locomotion;
+pub mod ui;
+pub mod assets;
+
+pub struct EnginePlugin;
+
+impl Plugin for EnginePlugin {
+    fn build(&self, app: &mut App) {
+        // Deterministic fixed update at 60 Hz
+        app.insert_resource(Time::<Fixed>::from_hz(60.0));
+        app.add_schedule(Schedule::new(Network));
+
+        // Register core plugins
+        app.add_plugins((
+            input::InputPlugin,
+            camera::CameraPlugin,
+            locomotion::LocomotionPlugin,
+            ui::UiPlugin,
+            assets::AssetPlugin,
+        ));
+    }
+}
+
+/// Hook up lobby scene graph.
+pub fn lobby_scene(app: &mut App) {
+    let _ = app;
+    // TODO: provide lobby scene graph hooks
+}
+
+/// Automatically wire subsystems based on platform capabilities.
+pub fn auto_wire(app: &mut App, capabilities: platform_api::CapabilityFlags) {
+    let _ = (app, capabilities);
+    // TODO: enable subsystems based on capabilities
+}

--- a/crates/engine/src/locomotion.rs
+++ b/crates/engine/src/locomotion.rs
@@ -1,0 +1,12 @@
+use bevy::prelude::*;
+#[allow(unused_imports)]
+use bevy_rapier3d::prelude::*;
+
+/// Kinematic character controller built on Rapier.
+pub struct LocomotionPlugin;
+
+impl Plugin for LocomotionPlugin {
+    fn build(&self, _app: &mut App) {
+        // TODO: implement character controller
+    }
+}

--- a/crates/engine/src/ui.rs
+++ b/crates/engine/src/ui.rs
@@ -1,0 +1,10 @@
+use bevy::prelude::*;
+
+/// Basic UI and HUD scaffolding.
+pub struct UiPlugin;
+
+impl Plugin for UiPlugin {
+    fn build(&self, _app: &mut App) {
+        // TODO: implement UI systems
+    }
+}


### PR DESCRIPTION
## Summary
- add bevy-based engine crate with fixed update, network schedule, and core plugins
- include stubs for input, camera, locomotion, UI, and asset loading modules
- register engine crate in workspace

## Testing
- `npm run prettier`
- `cargo test -p arena-engine`


------
https://chatgpt.com/codex/tasks/task_e_68be04708eb8832388279a524ed1cade