### PR TITLE
Expand editor features and autosave

### DIFF
--- a/docs/Editor.md
+++ b/docs/Editor.md
@@ -17,8 +17,28 @@ Enable the editor and run the server:
 ARENA_EDITOR=true cargo run -p server
 ```
 
-Press `F1` in the client to toggle the editor UI. Create or modify entities,
-then save the scene to disk.
+Press `F1` in the client to toggle the editor UI. The editor supports multiple
+interaction modes:
+
+- **FirstPerson** – navigate the world while editing
+- **Orthographic** – top‑down/ortho manipulation
+- **PrefabPalette** – place prefabs from the palette
+- **CsgBrush** – carve geometry with CSG brushes
+- **SplineTool** – edit spline paths
+- **Volume** – mark volume points
+- **NavMesh** – bake and visualize navigation meshes
+- **Validation** – run structural, gameplay and performance checks
+
+Switch modes programmatically by updating `EditorClient::mode`. The client
+tracks undo/redo history via `snapshot`, `undo` and `redo` helpers.
+
+Levels are autosaved in the browser using OPFS with IndexedDB fallback via
+`store_level_locally`/`load_level_locally`. Exporting a level writes a
+deterministic TOML representation and hashed binaries to
+`assets/levels/<level_id>/`.
+
+The editor can play the current level in‑place using `play_in_editor`, which
+invokes authoritative rules provided by a `platform_api::GameModule`.
 
 ## Integration
 


### PR DESCRIPTION
## Summary
- add editor modes for volumes, navmesh, validation and spline tool
- expose undo/redo stacks and navmesh toggling in the editor client
- ensure level exports are deterministic and document new workflows

## Testing
- `npm run prettier`
- `cargo test -p editor`

------
https://chatgpt.com/codex/tasks/task_e_68be0c06151083239465408f2cda997f