### PR TITLE
feat: add duck hunt server module and level assets

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2377,11 +2377,15 @@ dependencies = [
 name = "duck_hunt_server"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
+ "bevy",
  "chrono",
  "glam",
  "leaderboard",
  "net",
+ "platform-api",
  "postcard",
+ "rand",
  "serde",
  "tempfile",
  "tokio",

--- a/assets/levels/duck_range_01/README.md
+++ b/assets/levels/duck_range_01/README.md
@@ -1,0 +1,3 @@
+# Duck Range 01
+
+Sample level for Duck Hunt demonstrating paths, weapon config, and HUD profile.

--- a/assets/levels/duck_range_01/level.toml
+++ b/assets/levels/duck_range_01/level.toml
@@ -1,0 +1,19 @@
+name = "duck_range_01"
+background = "sky.png"
+
+[[ducks]]
+path = [[-5.0, 1.0, 0.0], [5.0, 1.5, 0.0]]
+speed = 5.0
+
+[[ducks]]
+path = [[5.0, 1.0, 0.0], [-5.0, 2.0, 0.0]]
+speed = 4.0
+
+[weapon]
+max_ammo = 6
+reload_time = 2.0
+
+[hud]
+font = "fonts/FiraSans-Bold.ttf"
+font_size = 32.0
+color = "#ffffff"

--- a/crates/minigames/duck_hunt/Cargo.toml
+++ b/crates/minigames/duck_hunt/Cargo.toml
@@ -3,9 +3,6 @@ name = "duck_hunt_server"
 version = "0.1.0"
 edition = "2024"
 
-[lib]
-path = "server.rs"
-
 [dependencies]
 glam = { version = "0.24", features = ["serde"] }
 net = { path = "../../net" }
@@ -15,6 +12,15 @@ tokio = { version = "1", features = ["sync", "macros", "rt-multi-thread"] }
 leaderboard = { path = "../../leaderboard" }
 uuid = { version = "1", features = ["v4", "serde"] }
 chrono = { version = "0.4", features = ["serde", "clock"] }
+bevy = { version = "0.12", default-features = false, features = [
+    "bevy_render",
+    "bevy_core_pipeline",
+    "bevy_pbr",
+    "bevy_text",
+] }
+platform-api = { path = "../../platform-api" }
+anyhow = "1"
+rand = "0.8"
 
 [dev-dependencies]
 tempfile = "3"

--- a/crates/minigames/duck_hunt/src/lib.rs
+++ b/crates/minigames/duck_hunt/src/lib.rs
@@ -1,0 +1,79 @@
+use anyhow::Result;
+use bevy::prelude::*;
+use platform_api::{
+    AppState, CapabilityFlags, GameModule, ModuleContext, ModuleMetadata, ServerApp,
+};
+
+#[path = "../server.rs"]
+pub mod server;
+
+#[derive(Resource, Default, Debug)]
+pub struct Score(pub u32);
+
+#[derive(Resource)]
+pub struct HudProfile {
+    pub font: Handle<Font>,
+    pub font_size: f32,
+    pub color: Color,
+}
+
+fn setup(world: &mut World) {
+    let Some(asset_server) = world.get_resource::<AssetServer>() else {
+        return;
+    };
+    let font = asset_server.load("fonts/FiraSans-Bold.ttf");
+    world.insert_resource(HudProfile {
+        font,
+        font_size: 32.0,
+        color: Color::WHITE,
+    });
+    world.insert_resource(Score::default());
+}
+
+fn cleanup(world: &mut World) {
+    world.remove_resource::<HudProfile>();
+    world.remove_resource::<Score>();
+}
+
+pub fn award_score(world: &mut World, points: u32) {
+    let mut score = world.get_resource_or_insert_with(Score::default);
+    score.0 += points;
+}
+
+#[derive(Default)]
+pub struct DuckHuntModule;
+
+impl Plugin for DuckHuntModule {
+    fn build(&self, _app: &mut App) {}
+}
+
+impl GameModule for DuckHuntModule {
+    const ID: &'static str = "duck_hunt";
+
+    fn metadata() -> ModuleMetadata {
+        ModuleMetadata {
+            id: Self::ID.to_string(),
+            name: "Duck Hunt".to_string(),
+            version: "0.1.0".to_string(),
+            author: "Unknown".to_string(),
+            state: AppState::DuckHunt,
+            capabilities: CapabilityFlags::LOBBY_PAD,
+            max_players: 4,
+            icon: Handle::default(),
+        }
+    }
+
+    fn register(_app: &mut App) {}
+
+    fn enter(ctx: &mut ModuleContext) -> Result<()> {
+        setup(ctx.world());
+        Ok(())
+    }
+
+    fn exit(ctx: &mut ModuleContext) -> Result<()> {
+        cleanup(ctx.world());
+        Ok(())
+    }
+
+    fn server_register(_app: &mut ServerApp) {}
+}

--- a/crates/minigames/duck_hunt/tests/spawn_and_score.rs
+++ b/crates/minigames/duck_hunt/tests/spawn_and_score.rs
@@ -1,0 +1,26 @@
+use duck_hunt_server::{server::{spawn_wave, Server}, award_score, DuckHuntModule, Score};
+use platform_api::{ModuleContext, GameModule};
+use bevy::prelude::World;
+use std::time::Duration;
+
+#[test]
+fn spawns_are_deterministic() {
+    let mut server_a = Server { latency: Duration::from_secs(0), ducks: vec![], snapshot_txs: Vec::new() };
+    spawn_wave(&mut server_a, 42, 3);
+    let ducks_a = server_a.ducks.clone();
+
+    let mut server_b = Server { latency: Duration::from_secs(0), ducks: vec![], snapshot_txs: Vec::new() };
+    spawn_wave(&mut server_b, 42, 3);
+    assert_eq!(ducks_a, server_b.ducks);
+}
+
+#[test]
+fn scoring_accumulates() {
+    let mut world = World::new();
+    let mut ctx = ModuleContext::new(&mut world);
+    DuckHuntModule::enter(&mut ctx).unwrap();
+    award_score(&mut world, 1);
+    award_score(&mut world, 2);
+    let score = world.get_resource::<Score>().unwrap();
+    assert_eq!(score.0, 3);
+}


### PR DESCRIPTION
## Summary
- implement duck hunt server GameModule with HUD and scoring
- add deterministic duck spawns and hit validation hooks
- bundle duck_range_01 level pack with sample ducks and HUD profile
- add tests for deterministic spawns and scoring

## Testing
- `cargo test -p duck_hunt_server`
- `npm run prettier`


------
https://chatgpt.com/codex/tasks/task_e_68be0e8898fc832396bfbfbb9688fb33