### PR TITLE
Add WebRTC data channel config and RTT reconciliation test

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1873,6 +1873,7 @@ dependencies = [
  "duck_hunt",
  "editor",
  "engine",
+ "net",
  "null_module",
  "payments",
  "physics",
@@ -4566,6 +4567,14 @@ dependencies = [
  "wasm-bindgen-futures",
  "web-sys",
  "webrtc",
+]
+
+[[package]]
+name = "netcode-tests"
+version = "0.1.0"
+dependencies = [
+ "net",
+ "rand",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,4 +14,5 @@ members = [
     "crates/leaderboard",
     "crates/render",
     "crates/payments",
+    "tests",
 ]

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -37,6 +37,7 @@ render = { path = "../crates/render" }
 analytics = { path = "../crates/analytics" }
 payments = { path = "../crates/payments" }
 platform-api = { path = "../crates/platform-api" }
+netcode = { path = "../crates/net", package = "net" }
 bevy_rapier3d = { version = "0.24", default-features = false, features = ["dim3"] }
 reqwest = { version = "0.12", features = ["json", "blocking"], optional = true }
 

--- a/client/src/main.rs
+++ b/client/src/main.rs
@@ -5,6 +5,7 @@ use bevy::prelude::*;
 use duck_hunt::DuckHuntPlugin;
 use engine::{AppExt, EnginePlugin};
 mod lobby;
+mod net;
 use null_module::NullModule;
 use payments::{EntitlementList, EntitlementStore, UserId}; // fetch_entitlements and entitlements
 use physics::PhysicsPlugin;
@@ -44,6 +45,7 @@ fn main() {
     app.add_plugins(RenderPlugin)
         .add_plugins(PhysicsPlugin)
         .add_plugins(EnginePlugin)
+        .add_plugins(net::ClientNetPlugin)
         .add_plugins(lobby::LobbyPlugin);
     if entitlements.has(user, "duck_hunt") {
         app.add_game_module::<DuckHuntPlugin>();

--- a/client/src/net.rs
+++ b/client/src/net.rs
@@ -1,0 +1,24 @@
+use bevy::prelude::*;
+use netcode::client::ClientConnector;
+
+#[cfg(target_arch = "wasm32")]
+use wasm_bindgen_futures::spawn_local;
+
+#[cfg(target_arch = "wasm32")]
+fn start_connection() {
+    spawn_local(async move {
+        if let Ok(conn) = ClientConnector::new().await {
+            let _ = conn.signal("ws://localhost:9001").await;
+            std::mem::forget(conn);
+        }
+    });
+}
+
+pub struct ClientNetPlugin;
+
+impl Plugin for ClientNetPlugin {
+    fn build(&self, app: &mut App) {
+        #[cfg(target_arch = "wasm32")]
+        app.add_systems(Startup, start_connection);
+    }
+}

--- a/crates/net/src/client.rs
+++ b/crates/net/src/client.rs
@@ -10,6 +10,7 @@ use webrtc::api::APIBuilder;
 use webrtc::api::media_engine::MediaEngine;
 use webrtc::data_channel::RTCDataChannel;
 use webrtc::data_channel::data_channel_message::DataChannelMessage;
+use webrtc::data_channel::data_channel_init::RTCDataChannelInit;
 use webrtc::peer_connection::RTCPeerConnection;
 use webrtc::peer_connection::configuration::RTCConfiguration;
 
@@ -53,7 +54,14 @@ impl ClientConnector {
         m.register_default_codecs()?;
         let api = APIBuilder::new().with_media_engine(m).build();
         let pc = api.new_peer_connection(RTCConfiguration::default()).await?;
-        let dc = pc.create_data_channel("gamedata", None).await?;
+        let mut cfg = RTCDataChannelInit {
+            ordered: Some(false),
+            max_retransmits: Some(0),
+            ..Default::default()
+        };
+        let dc = pc
+            .create_data_channel("gamedata", Some(cfg))
+            .await?;
         setup_channel(&dc);
         let dc_trait: Arc<dyn DataSender> = dc.clone();
         *DATA_CHANNEL.lock().unwrap_or_else(|e| e.into_inner()) = Some(dc_trait);

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "netcode-tests"
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]
+netcode = { path = "../crates/net", package = "net" }
+rand = { version = "0.8", features = ["small_rng"] }
+
+[[test]]
+name = "netcode"
+path = "netcode.rs"

--- a/tests/netcode.rs
+++ b/tests/netcode.rs
@@ -1,0 +1,42 @@
+use netcode::message::InputFrame;
+use rand::{rngs::SmallRng, Rng, SeedableRng};
+use std::collections::BTreeMap;
+
+#[derive(Default)]
+struct PredictionState {
+    last_confirmed: u32,
+    pending: Vec<InputFrame>,
+}
+
+#[test]
+fn reconciliation_handles_variable_rtt() {
+    let mut state = PredictionState::default();
+    let mut rng = SmallRng::seed_from_u64(7);
+    let mut schedule: BTreeMap<u32, Vec<u32>> = BTreeMap::new();
+    let total_frames = 60u32;
+
+    for frame in 1..=total_frames {
+        state.pending.push(InputFrame { frame, data: Vec::new() });
+        let rtt_ms: u32 = rng.gen_range(20..=150);
+        let delay_frames = (rtt_ms as f32 / (1000.0 / 60.0)).ceil() as u32;
+        schedule.entry(frame + delay_frames).or_default().push(frame);
+        if let Some(arrivals) = schedule.remove(&frame) {
+            for confirmed in arrivals {
+                state.last_confirmed = confirmed;
+                state.pending.retain(|f| f.frame > confirmed);
+            }
+        }
+    }
+
+    for frame in (total_frames + 1)..=(total_frames + 20) {
+        if let Some(arrivals) = schedule.remove(&frame) {
+            for confirmed in arrivals {
+                state.last_confirmed = confirmed;
+                state.pending.retain(|f| f.frame > confirmed);
+            }
+        }
+    }
+
+    assert!(state.pending.is_empty());
+    assert_eq!(state.last_confirmed, total_frames);
+}


### PR DESCRIPTION
## Summary
- configure client data channel for unordered, unretransmitted delivery
- expose client connector plugin for WebRTC signaling
- add RTT reconciliation integration test

## Testing
- `npm run prettier`
- `cargo test -p net`
- `cargo test -p netcode-tests`
- `cargo test -p client` *(fails: The system library `alsa` required by crate `alsa-sys` was not found)*

------
https://chatgpt.com/codex/tasks/task_e_68be147c7fb08323904ee21fd9b33a17