### PR TITLE
Make signaling URL configurable

### DIFF
--- a/client/src/net.rs
+++ b/client/src/net.rs
@@ -18,10 +18,22 @@ struct ConnectorResource(Option<ClientConnector>);
 struct ConnectorTask(Task<Result<ClientConnector, String>>);
 
 #[cfg(target_arch = "wasm32")]
-fn start_connection(mut commands: Commands) {
+#[derive(Resource, Clone)]
+pub struct SignalUrl(pub String);
+
+#[cfg(target_arch = "wasm32")]
+fn resolve_signal_url(url: Option<Res<SignalUrl>>) -> String {
+    url.map(|u| u.0.clone())
+        .or_else(|| std::env::var("ARENA_SIGNAL_URL").ok())
+        .unwrap_or_else(|| "ws://localhost:3000/signal".to_string())
+}
+
+#[cfg(target_arch = "wasm32")]
+fn start_connection(mut commands: Commands, url: Option<Res<SignalUrl>>) {
+    let signal_url = resolve_signal_url(url);
     let task = AsyncComputeTaskPool::get().spawn_local(async move {
         match ClientConnector::new().await {
-            Ok(conn) => match conn.signal("ws://localhost:9001").await {
+            Ok(conn) => match conn.signal(&signal_url).await {
                 Ok(_) => Ok(conn),
                 Err(e) => Err(e.to_string()),
             },

--- a/client/tests/signal_url.rs
+++ b/client/tests/signal_url.rs
@@ -1,0 +1,13 @@
+use std::fs;
+
+#[test]
+fn default_signal_url() {
+    let src = fs::read_to_string("src/net.rs").expect("read net.rs");
+    assert!(src.contains("ws://localhost:3000/signal"));
+}
+
+#[test]
+fn no_old_default() {
+    let src = fs::read_to_string("src/net.rs").expect("read net.rs");
+    assert!(!src.contains("ws://localhost:9001"));
+}


### PR DESCRIPTION
## Summary
- Allow configuring the signaling endpoint via `SignalUrl` resource or `ARENA_SIGNAL_URL` env var
- Default to `ws://localhost:3000/signal` when no override is provided
- Add tests ensuring the new default endpoint is used

## Testing
- `npm run prettier`
- `cargo test --test signal_url` *(fails: The system library `alsa` required by crate `alsa-sys` was not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bebb46075483238b59134909772cb8