### PR TITLE
Remove default physics controller

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2392,6 +2392,7 @@ checksum = "75b325c5dbd37f80359721ad39aca5a29fb04c89279657cffdda8736d0c0b9d2"
 name = "duck_hunt"
 version = "0.1.0"
 dependencies = [
+ "analytics",
  "anyhow",
  "bevy",
  "net",

--- a/client/crates/physics/Cargo.toml
+++ b/client/crates/physics/Cargo.toml
@@ -4,5 +4,5 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
-bevy = { version = "0.12", default-features = false }
+bevy = { version = "0.12", default-features = false, features = ["bevy_render"] }
 bevy_rapier3d = { version = "0.24", default-features = false, features = ["dim3"] }

--- a/client/crates/physics/src/lib.rs
+++ b/client/crates/physics/src/lib.rs
@@ -5,15 +5,6 @@ pub struct PhysicsPlugin;
 
 impl Plugin for PhysicsPlugin {
     fn build(&self, app: &mut App) {
-        app.add_plugins(RapierPhysicsPlugin::<NoUserData>::default().in_fixed_schedule())
-            .add_systems(Startup, setup_character_controller);
+        app.add_plugins(RapierPhysicsPlugin::<NoUserData>::default().in_fixed_schedule());
     }
-}
-
-fn setup_character_controller(mut commands: Commands) {
-    commands.spawn((
-        RigidBody::KinematicPositionBased,
-        Collider::capsule_y(0.5, 0.5),
-        KinematicCharacterController::default(),
-    ));
 }

--- a/client/crates/physics/tests/no_stray_controller.rs
+++ b/client/crates/physics/tests/no_stray_controller.rs
@@ -1,0 +1,19 @@
+use bevy::prelude::*;
+use bevy_rapier3d::prelude::*;
+use physics::PhysicsPlugin;
+
+#[test]
+fn no_stray_controller_after_startup() {
+    let mut app = App::new();
+    app.add_plugins((MinimalPlugins, PhysicsPlugin));
+
+    // Run startup systems
+    app.update();
+
+    let count = app
+        .world
+        .query::<&KinematicCharacterController>()
+        .iter(&app.world)
+        .count();
+    assert_eq!(count, 0, "unexpected KinematicCharacterController spawned");
+}


### PR DESCRIPTION
## Summary
- drop automatic character controller spawn from `PhysicsPlugin`
- enable Bevy's render feature for physics
- add regression test ensuring no controller exists at startup

## Testing
- `npm run prettier`
- `cargo test -p physics`

------
https://chatgpt.com/codex/tasks/task_e_68beded83a6c83239444636ffee2deb6