### PR TITLE
Replace Stripe payments with OTP claim flow

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -209,12 +209,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc7eb209b1518d6bb87b283c20095f5228ecda460da70b44f0802523dea6da04"
 
 [[package]]
-name = "android-tzdata"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e999941b234f3131b00bc13c22d06e8c5ff726d1b6318ac7eb276997bbb4fef0"
-
-[[package]]
 name = "android_log-sys"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1802,17 +1796,16 @@ checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "chrono"
-version = "0.4.41"
+version = "0.4.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c469d952047f47f91b68d1cba3f10d63c11d73e4636f24f08daf0278abf01c4d"
+checksum = "145052bdd345b87320e369255277e3fb5152762ad123a901ef5c262dd38fe8d2"
 dependencies = [
- "android-tzdata",
  "iana-time-zone",
  "js-sys",
  "num-traits",
  "serde",
  "wasm-bindgen",
- "windows-link",
+ "windows-link 0.2.0",
 ]
 
 [[package]]
@@ -3355,15 +3348,6 @@ dependencies = [
 
 [[package]]
 name = "heck"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d621efb26863f0e9924c6ac577e8275e5e6b77455db64ffa6c65c904e9e132c"
-dependencies = [
- "unicode-segmentation",
-]
-
-[[package]]
-name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
@@ -3428,7 +3412,7 @@ checksum = "a56f203cd1c76362b69e3863fd987520ac36cf70a8c92627449b2f64a8cf7d65"
 dependencies = [
  "cfg-if 1.0.3",
  "libc",
- "windows-link",
+ "windows-link 0.1.3",
 ]
 
 [[package]]
@@ -3677,7 +3661,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.58.0",
+ "windows-core 0.61.2",
 ]
 
 [[package]]
@@ -4731,17 +4715,6 @@ dependencies = [
 name = "num-bigint"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f6f7833f2cbf2360a6cfd58cd41a53aa7a90bd4c202f5b1c7dd2ed73c57b2c3"
-dependencies = [
- "autocfg",
- "num-integer",
- "num-traits",
-]
-
-[[package]]
-name = "num-bigint"
-version = "0.4.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
 dependencies = [
  "num-integer",
@@ -5172,13 +5145,9 @@ checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 name = "payments"
 version = "0.1.0"
 dependencies = [
- "async-trait",
  "chrono",
- "hex",
- "hmac",
  "serde",
  "serde_json",
- "sha2",
  "uuid",
 ]
 
@@ -6187,9 +6156,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework-sys"
-version = "2.14.0"
+version = "2.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49db231d56a190491cb4aeda9527f1ad45345af50b0851622a7adb8c03b01c32"
+checksum = "cc1f0cbffaac4852523ce30d8bd3c5cdc873501d96ff467ca09b6767bb8cd5c0"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -7357,9 +7326,9 @@ checksum = "1dccffe3ce07af9386bfd29e80c0ab1a8205a2fc34e4bcd40364df902cfa8f3f"
 
 [[package]]
 name = "typewit"
-version = "1.14.0"
+version = "1.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e75c3b0d61c1d0e12b4b0fd5111f377c918e0227e9eb67434dcf9e6084646c6"
+checksum = "4c98488b93df24b7c794d6a58c4198d7a2abde676324beaca84f7fb5b39c0811"
 
 [[package]]
 name = "unicase"
@@ -8012,11 +7981,11 @@ checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
 
 [[package]]
 name = "winapi-util"
-version = "0.1.10"
+version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0978bf7171b3d90bac376700cb56d606feb40f251a475a5d6634613564460b22"
+checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.0",
 ]
 
 [[package]]
@@ -8089,6 +8058,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-core"
+version = "0.61.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0fdd3ddb90610c7638aa2b3a3ab2904fb9e5cdbecc643ddb3647212781c4ae3"
+dependencies = [
+ "windows-implement 0.60.0",
+ "windows-interface 0.59.1",
+ "windows-link 0.1.3",
+ "windows-result 0.3.4",
+ "windows-strings 0.4.2",
+]
+
+[[package]]
 name = "windows-implement"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8104,6 +8086,17 @@ name = "windows-implement"
 version = "0.58.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2bbd5b46c938e506ecbce286b6628a02171d56153ba733b6c741fc627ec9579b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.106",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.60.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a47fddd13af08290e67f4acabf4b459f647552718f683a7b415d290ac744a836"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -8133,10 +8126,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-interface"
+version = "0.59.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd9211b69f8dcdfa817bfd14bf1c97c9188afa36f4750130fcdf3f400eca9fa8"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.106",
+]
+
+[[package]]
 name = "windows-link"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e6ad25900d524eaabdbbb96d20b4311e1e7ae1699af4fb28c17ae66c80d798a"
+
+[[package]]
+name = "windows-link"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "45e46c0661abb7180e7b9c281db115305d49ca1709ab8242adf09666d2173c65"
 
 [[package]]
 name = "windows-registry"
@@ -8144,7 +8154,7 @@ version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b8a9ed28765efc97bbc954883f4e6796c33a06546ebafacbabee9696967499e"
 dependencies = [
- "windows-link",
+ "windows-link 0.1.3",
  "windows-result 0.3.4",
  "windows-strings 0.4.2",
 ]
@@ -8173,7 +8183,7 @@ version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56f42bd332cc6c8eac5af113fc0c1fd6a8fd2aa08a0119358686e5160d0586c6"
 dependencies = [
- "windows-link",
+ "windows-link 0.1.3",
 ]
 
 [[package]]
@@ -8192,7 +8202,7 @@ version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56e6c93f3a0c3b36176cb1327a4958a0353d5d166c2a35cb268ace15e91d3b57"
 dependencies = [
- "windows-link",
+ "windows-link 0.1.3",
 ]
 
 [[package]]
@@ -8238,6 +8248,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
 dependencies = [
  "windows-targets 0.53.3",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.61.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e201184e40b2ede64bc2ea34968b28e33622acdbbf37104f0e4a33f7abe657aa"
+dependencies = [
+ "windows-link 0.2.0",
 ]
 
 [[package]]
@@ -8292,7 +8311,7 @@ version = "0.53.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d5fe6031c4041849d7c496a8ded650796e7b6ecc19df1a431c1a363342e5dc91"
 dependencies = [
- "windows-link",
+ "windows-link 0.1.3",
  "windows_aarch64_gnullvm 0.53.0",
  "windows_aarch64_msvc 0.53.0",
  "windows_i686_gnu 0.53.0",
@@ -8653,18 +8672,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.26"
+version = "0.8.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1039dd0d3c310cf05de012d8a39ff557cb0d23087fd44cad61df08fc31907a2f"
+checksum = "0894878a5fa3edfd6da3f88c4805f4c8558e2b996227a3d864f47fe11e38282c"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.26"
+version = "0.8.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ecf5b4cc5364572d7f4c329661bcc82724222973f2cab6f050a4e5c22f75181"
+checksum = "88d2b8d9c68ad2b9e4340d7832716a4d21a22a1154777ad56ea55c51a9cf3831"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/client/src/main.rs
+++ b/client/src/main.rs
@@ -7,7 +7,7 @@ use engine::{AppExt, EnginePlugin};
 mod entitlements;
 mod lobby;
 mod net;
-use entitlements::{fetch_entitlements, ensure_session};
+use entitlements::{claim_entitlement, fetch_entitlements, ensure_session};
 use null_module::NullModule;
 use payments::{EntitlementStore, UserId};
 use physics::PhysicsPlugin;

--- a/crates/payments/Cargo.toml
+++ b/crates/payments/Cargo.toml
@@ -8,7 +8,3 @@ serde = { version = "1", features = ["derive"] }
 uuid = { version = "1", features = ["serde", "v4"] }
 chrono = { version = "0.4", features = ["serde"] }
 serde_json = "1"
-async-trait = "0.1"
-hmac = "0.12"
-sha2 = "0.10"
-hex = "0.4"

--- a/docs/Purchases.md
+++ b/docs/Purchases.md
@@ -17,12 +17,12 @@ curl http://localhost:3000/store
 2. The client posts the desired SKU to `/store/claim`:
    ```bash
    curl -X POST http://localhost:3000/store/claim \
-        -H 'X-Session: <user-id>' \
+        -H 'X-Session: <session-token>' \
         -H 'Content-Type: application/json' \
         -d '{"sku":"duck_hunt"}'
    ```
-   The server verifies the session and grants the entitlement using its
-   `EntitlementStore`.
+   The server verifies the session and records the entitlement in its
+   Scylla-backed store.
 3. The entitlement is persisted server-side and can be queried later.
 
 ## Entitlements

--- a/server/src/leaderboard.rs
+++ b/server/src/leaderboard.rs
@@ -182,7 +182,8 @@ mod tests {
         email::{EmailService, SmtpConfig},
         room,
     };
-    use ::payments::{Catalog, EntitlementStore, Sku};
+    use ::payments::{Catalog, Sku};
+    use crate::payments::EntitlementStore;
     use analytics::Analytics;
     use axum::Json;
     use axum::extract::{Path, State};
@@ -211,7 +212,6 @@ mod tests {
                 price_cents: 1000,
             }]),
             entitlements: EntitlementStore::default(),
-            entitlements_path: PathBuf::new(),
         db: None,
         });
 
@@ -252,7 +252,6 @@ mod tests {
             leaderboard: leaderboard.clone(),
             catalog: Catalog::new(vec![]),
             entitlements: EntitlementStore::default(),
-            entitlements_path: PathBuf::new(),
         db: None,
         });
 
@@ -294,7 +293,6 @@ mod tests {
             leaderboard: leaderboard.clone(),
             catalog: Catalog::new(vec![]),
             entitlements: EntitlementStore::default(),
-            entitlements_path: PathBuf::new(),
         db: None,
         });
 
@@ -337,7 +335,6 @@ mod tests {
             leaderboard: leaderboard.clone(),
             catalog: Catalog::new(vec![]),
             entitlements: EntitlementStore::default(),
-            entitlements_path: PathBuf::new(),
         db: None,
         });
 
@@ -381,7 +378,6 @@ mod tests {
             leaderboard: leaderboard.clone(),
             catalog: Catalog::new(vec![]),
             entitlements: EntitlementStore::default(),
-            entitlements_path: PathBuf::new(),
         db: None,
         });
 

--- a/server/src/payments.rs
+++ b/server/src/payments.rs
@@ -1,0 +1,64 @@
+use std::sync::Arc;
+use std::sync::RwLock;
+
+use chrono::Utc;
+use scylla::{IntoTypedRows, Session};
+use ::payments::{Entitlement, UserId};
+
+#[derive(Clone, Default)]
+pub struct EntitlementStore {
+    db: Option<Arc<Session>>,
+    inner: Arc<RwLock<Vec<Entitlement>>>,
+}
+
+impl EntitlementStore {
+    pub fn new(db: Option<Arc<Session>>) -> Self {
+        Self {
+            db,
+            inner: Arc::new(RwLock::new(Vec::new())),
+        }
+    }
+
+    pub async fn grant(&self, user_id: UserId, sku_id: String) {
+        if let Some(db) = &self.db {
+            let query = "INSERT INTO entitlements_by_user (user_id, sku_id, granted_at) VALUES (?, ?, ?)";
+            let _ = db.query(query, (user_id, sku_id.clone(), Utc::now())).await;
+        }
+        let mut inner = self.inner.write().unwrap();
+        if inner
+            .iter()
+            .any(|e| e.user_id == user_id && e.sku_id == sku_id)
+        {
+            return;
+        }
+        inner.push(Entitlement {
+            user_id,
+            sku_id,
+            granted_at: Utc::now(),
+        });
+    }
+
+    pub async fn list(&self, user_id: &str) -> Vec<String> {
+        if let Some(db) = &self.db {
+            if let Ok(id) = UserId::parse_str(user_id) {
+                let query = "SELECT sku_id FROM entitlements_by_user WHERE user_id = ?";
+                if let Ok(res) = db.query(query, (id,)).await {
+                    if let Some(rows) = res.rows {
+                        return rows
+                            .into_typed::<(String,)>()
+                            .filter_map(|r| r.ok().map(|(sku,)| sku))
+                            .collect();
+                    }
+                }
+            }
+        }
+        self
+            .inner
+            .read()
+            .unwrap()
+            .iter()
+            .filter(|e| e.user_id.to_string() == user_id)
+            .map(|e| e.sku_id.clone())
+            .collect()
+    }
+}

--- a/server/src/tests.rs
+++ b/server/src/tests.rs
@@ -13,7 +13,8 @@ use webrtc::api::media_engine::MediaEngine;
 use webrtc::peer_connection::configuration::RTCConfiguration;
 
 use crate::test_logger::{INIT, LOGGER};
-use ::payments::{Catalog, EntitlementStore, Sku};
+use ::payments::{Catalog, Sku};
+use crate::payments::EntitlementStore;
 use std::sync::Arc;
 use log::LevelFilter;
 use std::path::PathBuf;
@@ -90,7 +91,6 @@ async fn websocket_signaling_completes_handshake() {
             price_cents: 1000,
         }]),
         entitlements: EntitlementStore::default(),
-        entitlements_path: PathBuf::new(),
         db: None,
     });
 
@@ -157,7 +157,6 @@ async fn websocket_signaling_invalid_sdp_logs_and_closes() {
             price_cents: 1000,
         }]),
         entitlements: EntitlementStore::default(),
-        entitlements_path: PathBuf::new(),
         db: None,
     });
 
@@ -217,7 +216,6 @@ async fn websocket_signaling_unexpected_binary_logs_and_closes() {
             price_cents: 1000,
         }]),
         entitlements: EntitlementStore::default(),
-        entitlements_path: PathBuf::new(),
         db: None,
     });
 
@@ -277,7 +275,6 @@ async fn websocket_logs_unexpected_messages_and_closes() {
             price_cents: 1000,
         }]),
         entitlements: EntitlementStore::default(),
-        entitlements_path: PathBuf::new(),
         db: None,
     });
 
@@ -327,7 +324,6 @@ async fn mail_test_defaults_to_from_address() {
             price_cents: 1000,
         }]),
         entitlements: EntitlementStore::default(),
-        entitlements_path: PathBuf::new(),
         db: None,
     });
 
@@ -365,7 +361,6 @@ async fn mail_test_accepts_user_address_query() {
             price_cents: 1000,
         }]),
         entitlements: EntitlementStore::default(),
-        entitlements_path: PathBuf::new(),
         db: None,
     });
 
@@ -410,7 +405,6 @@ async fn mail_test_accepts_user_address_body() {
             price_cents: 1000,
         }]),
         entitlements: EntitlementStore::default(),
-        entitlements_path: PathBuf::new(),
         db: None,
     });
 
@@ -454,7 +448,6 @@ async fn mail_config_redacts_password() {
             price_cents: 1000,
         }]),
         entitlements: EntitlementStore::default(),
-        entitlements_path: PathBuf::new(),
         db: None,
     });
 
@@ -485,7 +478,6 @@ async fn admin_mail_config_route() {
             price_cents: 1000,
         }]),
         entitlements: EntitlementStore::default(),
-        entitlements_path: PathBuf::new(),
         db: None,
     });
 
@@ -507,187 +499,6 @@ async fn admin_mail_config_route() {
     assert_eq!(response.status(), StatusCode::OK);
 }
 
-#[tokio::test]
-async fn stripe_webhook_accepts_valid_signature() {
-    let secret = "whsec_test";
-
-    let cfg = SmtpConfig::default();
-    let email = Arc::new(EmailService::new(cfg.clone()).unwrap());
-    let leaderboard = ::leaderboard::LeaderboardService::new(
-        "sqlite::memory:",
-        std::path::PathBuf::from("replays"),
-    )
-    .await
-    .unwrap();
-    let rooms = room::RoomManager::new(leaderboard.clone());
-    let state = Arc::new(AppState {
-        email,
-        rooms,
-        smtp: cfg.clone(),
-        analytics: Analytics::new(true, None, false),
-        leaderboard,
-        catalog: Catalog::new(vec![Sku {
-            id: "basic".into(),
-            price_cents: 1000,
-        }]),
-        store: Arc::new(StripeClient::new(secret)),
-        entitlements: EntitlementStore::default(),
-        entitlements_path: PathBuf::new(),
-        db: None,
-    });
-
-    let app = Router::new()
-        .route("/stripe/webhook", post(stripe_webhook_handler))
-        .with_state(state.clone());
-
-    let user = ::payments::UserId::new_v4();
-    let payload = serde_json::json!({
-        "type": "checkout.session.completed",
-        "data": {"object": {"client_reference_id": user.to_string(), "metadata": {"sku": "basic"}}}
-    })
-    .to_string();
-
-    let timestamp = 12345;
-    use hmac::{Hmac, Mac};
-    use sha2::Sha256;
-    type HmacSha256 = Hmac<Sha256>;
-    let mut mac = HmacSha256::new_from_slice(secret.as_bytes()).unwrap();
-    mac.update(format!("{}.{}", timestamp, payload).as_bytes());
-    let sig = hex::encode(mac.finalize().into_bytes());
-    let header = format!("t={timestamp},v1={sig}");
-
-    let response = app
-        .oneshot(
-            Request::builder()
-                .method("POST")
-                .uri("/stripe/webhook")
-                .header("Stripe-Signature", header)
-                .header("content-type", "application/json")
-                .body(Body::from(payload))
-                .unwrap(),
-        )
-        .await
-        .unwrap();
-    assert_eq!(response.status(), StatusCode::OK);
-    assert!(state.entitlements.has(user, "basic"));
-    assert!(state.analytics.events().iter().any(|e| matches!(e, Event::PurchaseCompleted { sku, user: u } if sku == "basic" && u == &user.to_string())));
-}
-
-#[tokio::test]
-async fn stripe_webhook_rejects_invalid_signature() {
-    let secret = "whsec_test";
-
-    let cfg = SmtpConfig::default();
-    let email = Arc::new(EmailService::new(cfg.clone()).unwrap());
-    let leaderboard = ::leaderboard::LeaderboardService::new(
-        "sqlite::memory:",
-        std::path::PathBuf::from("replays"),
-    )
-    .await
-    .unwrap();
-    let rooms = room::RoomManager::new(leaderboard.clone());
-    let state = Arc::new(AppState {
-        email,
-        rooms,
-        smtp: cfg.clone(),
-        analytics: Analytics::new(true, None, false),
-        leaderboard,
-        catalog: Catalog::new(vec![Sku {
-            id: "basic".into(),
-            price_cents: 1000,
-        }]),
-        store: Arc::new(StripeClient::new(secret)),
-        entitlements: EntitlementStore::default(),
-        entitlements_path: PathBuf::new(),
-        db: None,
-    });
-
-    let app = Router::new()
-        .route("/stripe/webhook", post(stripe_webhook_handler))
-        .with_state(state.clone());
-
-    let user = ::payments::UserId::new_v4();
-    let payload = serde_json::json!({
-        "type": "checkout.session.completed",
-        "data": {"object": {"client_reference_id": user.to_string(), "metadata": {"sku": "basic"}}}
-    })
-    .to_string();
-
-    let header = "t=12345,v1=badsignature";
-
-    let response = app
-        .oneshot(
-            Request::builder()
-                .method("POST")
-                .uri("/stripe/webhook")
-                .header("Stripe-Signature", header)
-                .header("content-type", "application/json")
-                .body(Body::from(payload))
-                .unwrap(),
-        )
-        .await
-        .unwrap();
-    assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
-    assert!(!state.entitlements.has(user, "basic"));
-}
-
-#[tokio::test]
-async fn webhook_persists_entitlements() {
-    let cfg = SmtpConfig::default();
-    let email = Arc::new(EmailService::new(cfg.clone()).unwrap());
-    let leaderboard = ::leaderboard::LeaderboardService::new(
-        "sqlite::memory:",
-        std::path::PathBuf::from("replays"),
-    )
-    .await
-    .unwrap();
-    let rooms = room::RoomManager::new(leaderboard.clone());
-    let path = std::env::temp_dir().join(format!(
-        "entitlements-{}.json",
-        uuid::Uuid::new_v4()
-    ));
-    let state = Arc::new(AppState {
-        email,
-        rooms,
-        smtp: cfg.clone(),
-        analytics: Analytics::new(true, None, false),
-        leaderboard,
-        catalog: Catalog::new(vec![Sku {
-            id: "basic".into(),
-            price_cents: 1000,
-        }]),
-        store: Arc::new(MockStoreProvider::default()),
-        entitlements: EntitlementStore::default(),
-        entitlements_path: path.clone(),
-        db: None,
-    });
-
-    let app = crate::payments::routes().with_state(state.clone());
-    let user = ::payments::UserId::new_v4();
-    let payload = serde_json::json!({
-        "user_id": user,
-        "sku_id": "basic"
-    })
-    .to_string();
-    let response = app
-        .oneshot(
-            Request::builder()
-                .method("POST")
-                .uri("/webhook")
-                .header("Stripe-Signature", "test")
-                .header("content-type", "application/json")
-                .body(Body::from(payload))
-                .unwrap(),
-        )
-        .await
-        .unwrap();
-    assert_eq!(response.status(), StatusCode::OK);
-    assert!(state.entitlements.has(user, "basic"));
-    let data = std::fs::read_to_string(&path).unwrap();
-    let ents: Vec<Entitlement> = serde_json::from_str(&data).unwrap();
-    assert!(ents.iter().any(|e| e.user_id == user && e.sku_id == "basic"));
-    let _ = std::fs::remove_file(path);
-}
 
 #[tokio::test]
 async fn round_scores_appear_in_leaderboard() {
@@ -715,7 +526,6 @@ async fn round_scores_appear_in_leaderboard() {
             price_cents: 1000,
         }]),
         entitlements: EntitlementStore::default(),
-        entitlements_path: std::path::PathBuf::new(),
         db: None,
     });
 


### PR DESCRIPTION
## Summary
- remove Stripe payment code and tests
- add Scylla-backed entitlement store and `/store/claim` endpoint
- client claims entitlements after OTP login
- document OTP-based purchase flow

## Testing
- `npm run prettier`
- `cargo test` *(fails: The system library `alsa` required by crate `alsa-sys` was not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bf03bf43dc8323be91b495a6e53a82