### PR TITLE
feat: switch leaderboard to scylla and redis

### DIFF
--- a/crates/minigames/duck_hunt/server.rs
+++ b/crates/minigames/duck_hunt/server.rs
@@ -299,7 +299,8 @@ mod tests {
     #[tokio::test]
     async fn leaderboard_records_hit() {
         let tmp = tempfile::tempdir().unwrap();
-        let service = LeaderboardService::new("sqlite::memory:", tmp.path().into())
+        std::env::set_var("ARENA_REDIS_URL", "redis://127.0.0.1/");
+        let service = LeaderboardService::new("127.0.0.1:9042", tmp.path().into())
             .await
             .unwrap();
         let server = Server {
@@ -340,7 +341,8 @@ mod tests {
     #[tokio::test]
     async fn dispatches_analytics_events() {
         let tmp = tempfile::tempdir().unwrap();
-        let service = LeaderboardService::new("sqlite::memory:", tmp.path().into())
+        std::env::set_var("ARENA_REDIS_URL", "redis://127.0.0.1/");
+        let service = LeaderboardService::new("127.0.0.1:9042", tmp.path().into())
             .await
             .unwrap();
         let server = Server {

--- a/docs/Leaderboards.md
+++ b/docs/Leaderboards.md
@@ -1,14 +1,20 @@
 # Leaderboards
 
-This guide describes how to configure and use Arena's leaderboard service.
+Arena's leaderboard service persists results in Scylla and mirrors the
+top standings in Redis for fast reads. Scores are tracked in three windows:
+**daily**, **weekly**, and **all_time**.
 
 ## Configuration
 
-| Env var                 | CLI flag            | Description                          | Default              |
-| ----------------------- | ------------------- | ------------------------------------ | -------------------- |
-| `SCYLLA_URI`            | `--scylla-uri`      | Connection string for Scylla cluster | `127.0.0.1:9042`     |
-| `ARENA_REDIS_URL`       | `--redis-url`       | Redis URL for leaderboard cache      | `redis://127.0.0.1/` |
-| `ARENA_LEADERBOARD_MAX` | `--leaderboard-max` | Maximum entries per leaderboard      | `100`                |
+| Env var                 | CLI flag            | Description                              | Default              |
+| ----------------------- | ------------------- | ---------------------------------------- | -------------------- |
+| `SCYLLA_URI`            | `--scylla-uri`      | Comma‑separated list of Scylla nodes     | `127.0.0.1:9042`     |
+| `ARENA_REDIS_URL`       | `--redis-url`       | Redis URL for the top‑N cache            | `redis://127.0.0.1/` |
+| `ARENA_LEADERBOARD_MAX` | `--leaderboard-max` | Maximum entries mirrored per leaderboard | `100`                |
+
+Each score submission writes a run and windowed score to Scylla.
+The highest `ARENA_LEADERBOARD_MAX` scores for each window are maintained
+in Redis sorted sets for quick retrieval.
 
 ## Usage
 
@@ -27,8 +33,6 @@ curl https://server/leaderboard/top
 ## Integration
 
 The `leaderboard` crate exposes an API for submitting and querying scores.
-Scores are stored in Scylla and the top standings for each leaderboard window
-(`daily`, `weekly`, and `all_time`) are mirrored in Redis for fast access.
 Register `LeaderboardPlugin` on the server to persist results and on the
 client to display standings.
 

--- a/server/src/tests.rs
+++ b/server/src/tests.rs
@@ -19,6 +19,13 @@ use std::sync::Arc;
 use log::LevelFilter;
 use std::path::PathBuf;
 
+async fn leaderboard_service() -> ::leaderboard::LeaderboardService {
+    std::env::set_var("ARENA_REDIS_URL", "redis://127.0.0.1/");
+    ::leaderboard::LeaderboardService::new("127.0.0.1:9042", PathBuf::from("replays"))
+        .await
+        .unwrap()
+}
+
 #[tokio::test]
 async fn setup_succeeds_without_env_vars() {
     unsafe {
@@ -73,12 +80,7 @@ fn invalid_starttls_env_value_errors() {
 async fn websocket_signaling_completes_handshake() {
     let cfg = SmtpConfig::default();
     let email = Arc::new(EmailService::new(cfg.clone()).unwrap());
-    let leaderboard = ::leaderboard::LeaderboardService::new(
-        "sqlite::memory:",
-        std::path::PathBuf::from("replays"),
-    )
-    .await
-    .unwrap();
+    let leaderboard = leaderboard_service().await;
     let rooms = room::RoomManager::new(leaderboard.clone());
     let state = Arc::new(AppState {
         email,
@@ -139,12 +141,7 @@ async fn websocket_signaling_invalid_sdp_logs_and_closes() {
 
     let cfg = SmtpConfig::default();
     let email = Arc::new(EmailService::new(cfg.clone()).unwrap());
-    let leaderboard = ::leaderboard::LeaderboardService::new(
-        "sqlite::memory:",
-        std::path::PathBuf::from("replays"),
-    )
-    .await
-    .unwrap();
+    let leaderboard = leaderboard_service().await;
     let rooms = room::RoomManager::new(leaderboard.clone());
     let state = Arc::new(AppState {
         email,
@@ -198,12 +195,7 @@ async fn websocket_signaling_unexpected_binary_logs_and_closes() {
 
     let cfg = SmtpConfig::default();
     let email = Arc::new(EmailService::new(cfg.clone()).unwrap());
-    let leaderboard = ::leaderboard::LeaderboardService::new(
-        "sqlite::memory:",
-        std::path::PathBuf::from("replays"),
-    )
-    .await
-    .unwrap();
+    let leaderboard = leaderboard_service().await;
     let rooms = room::RoomManager::new(leaderboard.clone());
     let state = Arc::new(AppState {
         email,
@@ -257,12 +249,7 @@ async fn websocket_logs_unexpected_messages_and_closes() {
 
     let cfg = SmtpConfig::default();
     let email = Arc::new(EmailService::new(cfg.clone()).unwrap());
-    let leaderboard = ::leaderboard::LeaderboardService::new(
-        "sqlite::memory:",
-        std::path::PathBuf::from("replays"),
-    )
-    .await
-    .unwrap();
+    let leaderboard = leaderboard_service().await;
     let rooms = room::RoomManager::new(leaderboard.clone());
     let state = Arc::new(AppState {
         email,
@@ -306,12 +293,7 @@ async fn mail_test_defaults_to_from_address() {
     let mut cfg = SmtpConfig::default();
     cfg.from = "default@example.com".into();
     let email = Arc::new(EmailService::new(cfg.clone()).unwrap());
-    let leaderboard = ::leaderboard::LeaderboardService::new(
-        "sqlite::memory:",
-        std::path::PathBuf::from("replays"),
-    )
-    .await
-    .unwrap();
+    let leaderboard = leaderboard_service().await;
     let rooms = room::RoomManager::new(leaderboard.clone());
     let state = Arc::new(AppState {
         email,
@@ -343,12 +325,7 @@ async fn mail_test_accepts_user_address_query() {
     let mut cfg = SmtpConfig::default();
     cfg.from = "query@example.com".into();
     let email = Arc::new(EmailService::new(cfg.clone()).unwrap());
-    let leaderboard = ::leaderboard::LeaderboardService::new(
-        "sqlite::memory:",
-        std::path::PathBuf::from("replays"),
-    )
-    .await
-    .unwrap();
+    let leaderboard = leaderboard_service().await;
     let rooms = room::RoomManager::new(leaderboard.clone());
     let state = Arc::new(AppState {
         email,
@@ -387,12 +364,7 @@ async fn mail_test_accepts_user_address_body() {
     let mut cfg = SmtpConfig::default();
     cfg.from = "body@example.com".into();
     let email = Arc::new(EmailService::new(cfg.clone()).unwrap());
-    let leaderboard = ::leaderboard::LeaderboardService::new(
-        "sqlite::memory:",
-        std::path::PathBuf::from("replays"),
-    )
-    .await
-    .unwrap();
+    let leaderboard = leaderboard_service().await;
     let rooms = room::RoomManager::new(leaderboard.clone());
     let state = Arc::new(AppState {
         email,
@@ -430,12 +402,7 @@ async fn mail_config_redacts_password() {
     let mut cfg = SmtpConfig::default();
     cfg.pass = Some("secret".into());
     let email = Arc::new(EmailService::new(cfg.clone()).unwrap());
-    let leaderboard = ::leaderboard::LeaderboardService::new(
-        "sqlite::memory:",
-        std::path::PathBuf::from("replays"),
-    )
-    .await
-    .unwrap();
+    let leaderboard = leaderboard_service().await;
     let rooms = room::RoomManager::new(leaderboard.clone());
     let state = Arc::new(AppState {
         email,
@@ -460,12 +427,7 @@ async fn mail_config_redacts_password() {
 async fn admin_mail_config_route() {
     let cfg = SmtpConfig::default();
     let email = Arc::new(EmailService::new(cfg.clone()).unwrap());
-    let leaderboard = ::leaderboard::LeaderboardService::new(
-        "sqlite::memory:",
-        std::path::PathBuf::from("replays"),
-    )
-    .await
-    .unwrap();
+    let leaderboard = leaderboard_service().await;
     let rooms = room::RoomManager::new(leaderboard.clone());
     let state = Arc::new(AppState {
         email,
@@ -507,12 +469,7 @@ async fn round_scores_appear_in_leaderboard() {
 
     let cfg = SmtpConfig::default();
     let email = Arc::new(EmailService::new(cfg.clone()).unwrap());
-    let leaderboard = ::leaderboard::LeaderboardService::new(
-        "sqlite::memory:",
-        std::path::PathBuf::from("replays"),
-    )
-    .await
-    .unwrap();
+    let leaderboard = leaderboard_service().await;
     let rooms = room::RoomManager::new(leaderboard.clone());
     rooms.push_score(7).await;
     let state = Arc::new(AppState {


### PR DESCRIPTION
## Summary
- store runs and scores in Scylla and mirror top results in Redis
- swap tests and examples to use Scylla/Redis rather than SQLite
- document Scylla URI, Redis cache, and leaderboard windows

## Testing
- `npm run prettier`
- `cargo test` *(fails: The system library `alsa` required by crate `alsa-sys` was not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bf089665a48323acbce2dbe3e516f2