### PR TITLE
Require Redis URL for leaderboard service

### DIFF
--- a/crates/leaderboard/tests/redis_url.rs
+++ b/crates/leaderboard/tests/redis_url.rs
@@ -1,0 +1,8 @@
+use leaderboard::LeaderboardService;
+
+#[tokio::test]
+async fn constructor_errors_without_redis_url() {
+    std::env::remove_var("ARENA_REDIS_URL");
+    let result = LeaderboardService::new("localhost:9042", std::env::temp_dir()).await;
+    assert!(result.is_err());
+}

--- a/docs/Config.md
+++ b/docs/Config.md
@@ -50,10 +50,10 @@ provided when launching the server.
 
 ## Leaderboards
 
-| Env var                 | CLI flag            | Description                              | Default              |
-| ----------------------- | ------------------- | ---------------------------------------- | -------------------- |
-| `ARENA_REDIS_URL`       | `--redis-url`       | Redis URL for the top‑N cache            | `redis://127.0.0.1/` |
-| `ARENA_LEADERBOARD_MAX` | `--leaderboard-max` | Maximum entries mirrored per leaderboard | `100`                |
+| Env var                 | CLI flag            | Description                                  | Default |
+| ----------------------- | ------------------- | -------------------------------------------- | ------- |
+| `ARENA_REDIS_URL`       | `--redis-url`       | Redis URL for the top‑N cache **(required)** | -       |
+| `ARENA_LEADERBOARD_MAX` | `--leaderboard-max` | Maximum entries mirrored per leaderboard     | `100`   |
 
 ## Editor
 

--- a/docs/Leaderboards.md
+++ b/docs/Leaderboards.md
@@ -6,11 +6,11 @@ top standings in Redis for fast reads. Scores are tracked in three windows:
 
 ## Configuration
 
-| Env var                 | CLI flag            | Description                              | Default              |
-| ----------------------- | ------------------- | ---------------------------------------- | -------------------- |
-| `ARENA_DB_URL`          | `--db-url`          | Scylla database URL                      | -                    |
-| `ARENA_REDIS_URL`       | `--redis-url`       | Redis URL for the top‑N cache            | `redis://127.0.0.1/` |
-| `ARENA_LEADERBOARD_MAX` | `--leaderboard-max` | Maximum entries mirrored per leaderboard | `100`                |
+| Env var                 | CLI flag            | Description                                  | Default |
+| ----------------------- | ------------------- | -------------------------------------------- | ------- |
+| `ARENA_DB_URL`          | `--db-url`          | Scylla database URL                          | -       |
+| `ARENA_REDIS_URL`       | `--redis-url`       | Redis URL for the top‑N cache **(required)** | -       |
+| `ARENA_LEADERBOARD_MAX` | `--leaderboard-max` | Maximum entries mirrored per leaderboard     | `100`   |
 
 Each score submission writes a run and windowed score to Scylla.
 The highest `ARENA_LEADERBOARD_MAX` scores for each window are maintained


### PR DESCRIPTION
## Summary
- remove fallback Redis URL and error if ARENA_REDIS_URL is unset
- document ARENA_REDIS_URL as a required configuration variable
- add regression test for missing Redis URL

## Testing
- `npm run prettier`
- `cargo test -p leaderboard` *(fails: unresolved crate `anyhow`, `SerializeCql` not implemented for `DateTime<Utc>`)*

------
https://chatgpt.com/codex/tasks/task_e_68bfc65fb834832391bf79632874df8b