### PR TITLE
Consolidate axum imports in server main

### DIFF
--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -6,7 +6,7 @@ use crate::email::{EmailService, SmtpConfig, StartTls};
 use ::payments::{Catalog, EntitlementList, Sku, UserId};
 use analytics::{Analytics, Event};
 use axum::{
-    Extension, Extension, Router, Router,
+    Extension, Router,
     extract::{
         Json, Path, Query, State,
         ws::{Message, WebSocket, WebSocketUpgrade},


### PR DESCRIPTION
## Summary
- dedupe axum imports in server main.rs

## Testing
- `npm run prettier`
- `cargo check -p server` *(fails: command terminated before completion due to environment limits)*

------
https://chatgpt.com/codex/tasks/task_e_68bfc66606308323ab900b4415c76d33