### PR TITLE
Handle response text errors in WASM config loader

### DIFF
--- a/client/src/config.rs
+++ b/client/src/config.rs
@@ -51,7 +51,15 @@ impl RuntimeConfig {
             }
         };
 
-        let text = match JsFuture::from(resp.text().unwrap()).await {
+        let text_promise = match resp.text() {
+            Ok(promise) => promise,
+            Err(e) => {
+                web_sys::console::error_1(&e);
+                return Self::default();
+            }
+        };
+
+        let text = match JsFuture::from(text_promise).await {
             Ok(v) => v.as_string().unwrap_or_default(),
             Err(e) => {
                 web_sys::console::error_1(&e);


### PR DESCRIPTION
## Summary
- Handle failures from `Response::text` in WASM runtime config loader by logging and returning a default config

## Testing
- `cargo check -p client` *(fails: `Analytics` missing `Resource` trait in duck_hunt crate)*
- `cargo check -p client --target wasm32-unknown-unknown` *(fails: `getrandom` unsupported for `wasm32-unknown-unknown`)*
- `npm run prettier`

------
https://chatgpt.com/codex/tasks/task_e_68bfc66d504c832380fb8ae9e37f577c