### PR TITLE
feat: add analytics flags to runtime config

### DIFF
--- a/client/src/config.rs
+++ b/client/src/config.rs
@@ -10,6 +10,10 @@ pub struct RuntimeConfig {
     pub feature_flags: HashMap<String, bool>,
     #[serde(default)]
     pub ice_servers: Vec<String>,
+    #[serde(default)]
+    pub analytics_enabled: bool,
+    #[serde(default)]
+    pub analytics_opt_out: bool,
 }
 
 impl Default for RuntimeConfig {
@@ -19,6 +23,8 @@ impl Default for RuntimeConfig {
             api_base_url: String::new(),
             feature_flags: HashMap::new(),
             ice_servers: Vec::new(),
+            analytics_enabled: false,
+            analytics_opt_out: false,
         }
     }
 }

--- a/client/src/main.rs
+++ b/client/src/main.rs
@@ -23,7 +23,7 @@ static ALLOC: wee_alloc::WeeAlloc = wee_alloc::WeeAlloc::INIT;
 #[cfg(not(target_arch = "wasm32"))]
 fn main() {
     let config = future::block_on(RuntimeConfig::load());
-    let enabled = std::env::var("ARENA_ANALYTICS_OPT_OUT").is_err();
+    let enabled = config.analytics_enabled && !config.analytics_opt_out;
     let analytics = Analytics::new(enabled, None, None);
     analytics.dispatch(Event::SessionStart);
     analytics.dispatch(Event::LevelStart { level: 1 });
@@ -59,7 +59,7 @@ use wasm_bindgen::prelude::*;
 #[wasm_bindgen(start)]
 pub async fn main() -> Result<(), JsValue> {
     let config = RuntimeConfig::load().await;
-    let enabled = std::env::var("ARENA_ANALYTICS_OPT_OUT").is_err();
+    let enabled = config.analytics_enabled && !config.analytics_opt_out;
     let analytics = Analytics::new(enabled, None, None);
     analytics.dispatch(Event::SessionStart);
     analytics.dispatch(Event::LevelStart { level: 1 });


### PR DESCRIPTION
## Summary
- parse analytics settings in client runtime config
- use analytics flags when initializing client analytics

## Testing
- `npm run prettier`
- `cargo test -p client` *(fails: Analytics does not implement Resource)*

------
https://chatgpt.com/codex/tasks/task_e_68bfc653117883239a7e5775f965e1a7