### PR TITLE
Parse structured ICE server config

### DIFF
--- a/client/src/config.rs
+++ b/client/src/config.rs
@@ -1,5 +1,5 @@
 use bevy::prelude::*;
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
 #[derive(Resource, Clone, Deserialize)]
@@ -9,11 +9,45 @@ pub struct RuntimeConfig {
     #[serde(default)]
     pub feature_flags: HashMap<String, bool>,
     #[serde(default)]
-    pub ice_servers: Vec<String>,
+    pub ice_servers: Vec<IceServerConfig>,
     #[serde(default)]
     pub analytics_enabled: bool,
     #[serde(default)]
     pub analytics_opt_out: bool,
+}
+
+#[derive(Clone, Deserialize, Serialize)]
+pub struct IceServerConfig {
+    #[serde(deserialize_with = "deserialize_urls", serialize_with = "serialize_urls")]
+    pub urls: Vec<String>,
+    #[serde(default)]
+    pub username: Option<String>,
+    #[serde(default)]
+    pub credential: Option<String>,
+}
+
+fn deserialize_urls<'de, D>(deserializer: D) -> Result<Vec<String>, D::Error>
+where
+    D: serde::de::Deserializer<'de>,
+{
+    #[derive(Deserialize)]
+    #[serde(untagged)]
+    enum Urls {
+        Single(String),
+        Multiple(Vec<String>),
+    }
+
+    match Urls::deserialize(deserializer)? {
+        Urls::Single(url) => Ok(vec![url]),
+        Urls::Multiple(urls) => Ok(urls),
+    }
+}
+
+fn serialize_urls<S>(urls: &Vec<String>, serializer: S) -> Result<S::Ok, S::Error>
+where
+    S: serde::ser::Serializer,
+{
+    urls.serialize(serializer)
 }
 
 impl Default for RuntimeConfig {

--- a/server/src/config.rs
+++ b/server/src/config.rs
@@ -2,7 +2,7 @@ use axum::{Json, extract::Extension};
 use serde::Serialize;
 use std::collections::HashMap;
 
-use crate::ResolvedConfig;
+use crate::{IceServerConfig, ResolvedConfig};
 
 /// Public configuration returned to clients.
 #[derive(Serialize)]
@@ -21,7 +21,7 @@ pub struct ConfigResponse {
     pub feature_flags: HashMap<String, bool>,
     /// ICE servers used for establishing peer connections
     #[serde(default)]
-    pub ice_servers: Vec<String>,
+    pub ice_servers: Vec<IceServerConfig>,
 }
 
 /// HTTP handler that returns public configuration as JSON.


### PR DESCRIPTION
## Summary
- Parse `ARENA_RTC_ICE_SERVERS_JSON` into structured ICE server definitions.
- Expose ICE server details to clients via `ConfigResponse` and `RuntimeConfig`.

## Testing
- `npm run prettier`
- `npm test`
- `cargo test` *(fails: trait `Resource` not implemented for `Analytics` in duck_hunt crate)*

------
https://chatgpt.com/codex/tasks/task_e_68bfcabaf5b48323b9366f2eb9ef3645