### PR TITLE
Remove redundant SMTP validation

### DIFF
--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -440,7 +440,6 @@ async fn shutdown_signal() {
 }
 
 async fn setup(cfg: &ResolvedConfig, smtp: SmtpConfig, analytics: Analytics) -> Result<AppState> {
-    let smtp = smtp.validate()?;
     let email = Arc::new(EmailService::new(smtp.clone()).map_err(|e| {
         log::error!("failed to initialize email service: {e}");
         anyhow!(e)
@@ -498,7 +497,6 @@ async fn run(cli: Cli) -> Result<()> {
         posthog_key.clone(),
         metrics_addr,
     );
-    let smtp = smtp.validate()?;
     let state = Arc::new(setup(&config, smtp, analytics).await?);
 
     let assets_service =


### PR DESCRIPTION
## Summary
- rely on `EmailService::new` for SMTP config validation
- pass `SmtpConfig` to setup without duplicate calls

## Testing
- `npm run prettier`
- `cargo test -p server` *(fails: unresolved import `anyhow` in leaderboard crate)*

------
https://chatgpt.com/codex/tasks/task_e_68bfcaa3f62483238f0dd14c96f26c85