### PR TITLE
Track EmailService instances for cleanup task

### DIFF
--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -629,7 +629,6 @@ async fn run(cli: Cli) -> Result<()> {
     let res = axum::serve(listener, app)
         .with_graceful_shutdown(shutdown_signal())
         .await;
-    state.email.abort_cleanup();
     res.map_err(|e| {
         log::error!("server error: {e}");
         e


### PR DESCRIPTION
## Summary
- Track active `EmailService` instances and spawn a cleanup task only while at least one service exists
- Remove manual cleanup abort and rely on drop to stop the task
- Add lifecycle test ensuring cleanup task starts and stops with services

## Testing
- `npm run prettier`
- `cargo test -p server` *(fails: unresolved import `anyhow` in leaderboard crate)*

------
https://chatgpt.com/codex/tasks/task_e_68bfd96fedd083238d498c6329d42606