### PR TITLE
Add server configuration options and expose to clients

### DIFF
--- a/client/src/config.rs
+++ b/client/src/config.rs
@@ -14,6 +14,10 @@ pub struct RuntimeConfig {
     pub analytics_enabled: bool,
     #[serde(default)]
     pub analytics_opt_out: bool,
+    #[serde(default)]
+    pub enable_coop_coep: bool,
+    #[serde(default)]
+    pub enable_sw: bool,
 }
 
 #[derive(Clone, Deserialize, Serialize, Debug, PartialEq)]
@@ -59,6 +63,8 @@ impl Default for RuntimeConfig {
             ice_servers: Vec::new(),
             analytics_enabled: false,
             analytics_opt_out: false,
+            enable_coop_coep: false,
+            enable_sw: false,
         }
     }
 }

--- a/crates/storage/src/lib.rs
+++ b/crates/storage/src/lib.rs
@@ -1,8 +1,10 @@
 use anyhow::Result;
-use sea_orm::{Database, DatabaseConnection};
+use sea_orm::{ConnectOptions, Database, DatabaseConnection};
 
 /// Connect to the database and return a SeaORM [`DatabaseConnection`].
-pub async fn connect(db_url: &str) -> Result<DatabaseConnection> {
-    let db = Database::connect(db_url).await?;
+pub async fn connect(db_url: &str, max_connections: u32) -> Result<DatabaseConnection> {
+    let mut opts = ConnectOptions::new(db_url.to_owned());
+    opts.max_connections(max_connections);
+    let db = Database::connect(opts).await?;
     Ok(db)
 }

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -36,7 +36,6 @@ hex = "0.4"
 rand = "0.8"
 sea-orm = { version = "0.12", features=["sqlx-postgres","runtime-tokio-rustls","macros"] }
 storage = { path = "../crates/storage" }
-sea-orm = { version = "0.12", features = ["sqlx-postgres", "runtime-tokio-rustls"] }
 migration = { path = "migration" }
 
 redis = { version = "0.24", optional = true, default-features = false, features = ["tokio-comp"] }

--- a/server/src/config.rs
+++ b/server/src/config.rs
@@ -22,6 +22,12 @@ pub struct ConfigResponse {
     /// ICE servers used for establishing peer connections
     #[serde(default)]
     pub ice_servers: Vec<IceServerConfig>,
+    /// Whether COOP/COEP headers are enabled
+    #[serde(default)]
+    pub enable_coop_coep: bool,
+    /// Whether service workers are enabled
+    #[serde(default)]
+    pub enable_sw: bool,
 }
 
 /// HTTP handler that returns public configuration as JSON.
@@ -33,6 +39,8 @@ pub async fn get_config(Extension(cfg): Extension<ResolvedConfig>) -> Json<Confi
         analytics_opt_out: cfg.analytics_opt_out,
         feature_flags: cfg.feature_flags.clone(),
         ice_servers: cfg.ice_servers.clone(),
+        enable_coop_coep: cfg.enable_coop_coep,
+        enable_sw: cfg.enable_sw,
     };
     Json(cfg)
 }

--- a/server/src/tests.rs
+++ b/server/src/tests.rs
@@ -47,6 +47,12 @@ async fn setup_succeeds_without_env_vars() {
         public_base_url: "http://localhost".into(),
         signaling_ws_url: "ws://127.0.0.1".into(),
         db_url: "127.0.0.1:9042".into(),
+        db_max_conns: 1,
+        migrate_on_start: false,
+        enable_coop_coep: false,
+        static_dir: PathBuf::from("static"),
+        assets_dir: PathBuf::from("assets"),
+        enable_sw: false,
         csp: None,
         ice_servers: Vec::new(),
         feature_flags: HashMap::new(),
@@ -132,6 +138,9 @@ async fn config_json_respects_cli_overrides() {
         env::set_var("ARENA_PUBLIC_BASE_URL", "http://env");
         env::set_var("ARENA_SIGNALING_WS_URL", "ws://env");
         env::set_var("ARENA_DB_URL", "envdb");
+        env::set_var("ARENA_DB_MAX_CONNS", "1");
+        env::set_var("ARENA_STATIC_DIR", "static");
+        env::set_var("ARENA_ASSETS_DIR", "assets");
         env::set_var("ARENA_ANALYTICS_OPT_OUT", "false");
     }
     let cli =
@@ -147,6 +156,9 @@ async fn config_json_respects_cli_overrides() {
         env::remove_var("ARENA_PUBLIC_BASE_URL");
         env::remove_var("ARENA_SIGNALING_WS_URL");
         env::remove_var("ARENA_DB_URL");
+        env::remove_var("ARENA_DB_MAX_CONNS");
+        env::remove_var("ARENA_STATIC_DIR");
+        env::remove_var("ARENA_ASSETS_DIR");
         env::remove_var("ARENA_ANALYTICS_OPT_OUT");
     }
 }


### PR DESCRIPTION
## Summary
- support database connection limits, migrations on start, service worker toggles, and COOP/COEP headers
- allow configuring static and asset directories
- surface selected settings to clients via `/config.json`

## Testing
- `npm test`
- `cargo test -p client` *(fails: package `bigdecimal` is specified twice in the lockfile)*
- `cargo test -p server` *(fails: package `bigdecimal` is specified twice in the lockfile)*


------
https://chatgpt.com/codex/tasks/task_e_68bff98515b88323a5acd3e8992d1278