### PR TITLE
feat: persist entitlements and purchases with SeaORM

### DIFF
--- a/server/migration/src/lib.rs
+++ b/server/migration/src/lib.rs
@@ -9,6 +9,8 @@ mod m20240101_000006_create_sessions;
 mod m20240101_000007_create_rate_limits;
 mod m20240101_000008_create_leaderboard;
 mod m20240101_000009_create_leaderboard_tables;
+mod m20240101_000010_create_entitlements;
+mod m20240101_000011_create_purchases;
 
 pub struct Migrator;
 
@@ -25,6 +27,8 @@ impl MigratorTrait for Migrator {
             Box::new(m20240101_000007_create_rate_limits::Migration),
             Box::new(m20240101_000008_create_leaderboard::Migration),
             Box::new(m20240101_000009_create_leaderboard_tables::Migration),
+            Box::new(m20240101_000010_create_entitlements::Migration),
+            Box::new(m20240101_000011_create_purchases::Migration),
         ]
     }
 }

--- a/server/migration/src/m20240101_000010_create_entitlements.rs
+++ b/server/migration/src/m20240101_000010_create_entitlements.rs
@@ -1,0 +1,47 @@
+use sea_orm_migration::prelude::*;
+
+#[derive(DeriveMigrationName)]
+pub struct Migration;
+
+#[async_trait::async_trait]
+impl MigrationTrait for Migration {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .create_table(
+                Table::create()
+                    .table(Entitlements::Table)
+                    .if_not_exists()
+                    .col(ColumnDef::new(Entitlements::UserId).uuid().not_null())
+                    .col(ColumnDef::new(Entitlements::SkuId).string().not_null())
+                    .col(
+                        ColumnDef::new(Entitlements::GrantedAt)
+                            .timestamp_with_time_zone()
+                            .not_null()
+                            .default(Expr::cust("NOW()")),
+                    )
+                    .primary_key(
+                        Index::create()
+                            .col(Entitlements::UserId)
+                            .col(Entitlements::SkuId),
+                    )
+                    .to_owned(),
+            )
+            .await?;
+        Ok(())
+    }
+
+    async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .drop_table(Table::drop().table(Entitlements::Table).to_owned())
+            .await?;
+        Ok(())
+    }
+}
+
+#[derive(Iden)]
+enum Entitlements {
+    Table,
+    UserId,
+    SkuId,
+    GrantedAt,
+}

--- a/server/migration/src/m20240101_000011_create_purchases.rs
+++ b/server/migration/src/m20240101_000011_create_purchases.rs
@@ -1,0 +1,59 @@
+use sea_orm_migration::prelude::*;
+
+#[derive(DeriveMigrationName)]
+pub struct Migration;
+
+#[async_trait::async_trait]
+impl MigrationTrait for Migration {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .create_table(
+                Table::create()
+                    .table(Purchases::Table)
+                    .if_not_exists()
+                    .col(
+                        ColumnDef::new(Purchases::Id)
+                            .big_integer()
+                            .not_null()
+                            .auto_increment()
+                            .primary_key(),
+                    )
+                    .col(ColumnDef::new(Purchases::UserId).uuid().not_null())
+                    .col(ColumnDef::new(Purchases::SkuId).string().not_null())
+                    .col(
+                        ColumnDef::new(Purchases::PurchasedAt)
+                            .timestamp_with_time_zone()
+                            .not_null()
+                            .default(Expr::cust("NOW()")),
+                    )
+                    .to_owned(),
+            )
+            .await?;
+        manager
+            .create_index(
+                Index::create()
+                    .name("idx_purchases_user_id")
+                    .table(Purchases::Table)
+                    .col(Purchases::UserId)
+                    .to_owned(),
+            )
+            .await?;
+        Ok(())
+    }
+
+    async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .drop_table(Table::drop().table(Purchases::Table).to_owned())
+            .await?;
+        Ok(())
+    }
+}
+
+#[derive(Iden)]
+enum Purchases {
+    Table,
+    Id,
+    UserId,
+    SkuId,
+    PurchasedAt,
+}

--- a/server/src/payments.rs
+++ b/server/src/payments.rs
@@ -1,120 +1,92 @@
-use std::sync::Arc;
-use std::sync::RwLock;
-
-use ::payments::{Entitlement, UserId};
+use ::payments::UserId;
 use chrono::Utc;
-use sea_orm::{DatabaseConnection, DbBackend, Statement, TryGetable};
+use sea_orm::{entity::prelude::*, DatabaseConnection, OnConflict, QueryFilter};
 
 #[derive(Clone, Default)]
 pub struct EntitlementStore {
     db: Option<DatabaseConnection>,
-    inner: Arc<RwLock<Vec<Entitlement>>>,
 }
 
 impl EntitlementStore {
     pub fn new(db: Option<DatabaseConnection>) -> Self {
-        Self {
-            db,
-            inner: Arc::new(RwLock::new(Vec::new())),
-        }
-    }
-
-    #[cfg(test)]
-    fn inner(&self) -> Arc<RwLock<Vec<Entitlement>>> {
-        self.inner.clone()
+        Self { db }
     }
 
     pub async fn grant(&self, user_id: UserId, sku_id: String) {
         if let Some(db) = &self.db {
-            let stmt = Statement::from_sql_and_values(
-                DbBackend::Postgres,
-                "INSERT INTO entitlements_by_user (user_id, sku_id, granted_at) VALUES ($1, $2, NOW())",
-                vec![user_id.to_string().into(), sku_id.clone().into()],
-            );
-            let _ = db.execute(stmt).await;
+            let active = entitlements::ActiveModel {
+                user_id: Set(user_id),
+                sku_id: Set(sku_id.clone()),
+                granted_at: Set(Utc::now()),
+            };
+            let _ = entitlements::Entity::insert(active)
+                .on_conflict(
+                    OnConflict::columns([
+                        entitlements::Column::UserId,
+                        entitlements::Column::SkuId,
+                    ])
+                    .do_nothing()
+                    .to_owned(),
+                )
+                .exec(db)
+                .await;
         }
-        let mut inner = match self.inner.write() {
-            Ok(inner) => inner,
-            Err(e) => e.into_inner(),
-        };
-        if inner
-            .iter()
-            .any(|e| e.user_id == user_id && e.sku_id == sku_id)
-        {
-            return;
-        }
-        inner.push(Entitlement {
-            user_id,
-            sku_id,
-            granted_at: Utc::now(),
-        });
     }
 
     pub async fn list(&self, user_id: &str) -> Vec<String> {
         if let Some(db) = &self.db {
             if let Ok(id) = UserId::parse_str(user_id) {
-                let stmt = Statement::from_sql_and_values(
-                    DbBackend::Postgres,
-                    "SELECT sku_id FROM entitlements_by_user WHERE user_id = $1",
-                    vec![id.to_string().into()],
-                );
-                if let Ok(rows) = db.query_all(stmt).await {
-                    return rows
-                        .into_iter()
-                        .filter_map(|row| row.try_get::<String>("sku_id").ok())
-                        .collect();
+                if let Ok(rows) = entitlements::Entity::find()
+                    .filter(entitlements::Column::UserId.eq(id))
+                    .all(db)
+                    .await
+                {
+                    return rows.into_iter().map(|e| e.sku_id).collect();
                 }
             }
         }
-        let inner = match self.inner.read() {
-            Ok(inner) => inner,
-            Err(e) => e.into_inner(),
-        };
-        inner
-            .iter()
-            .filter(|e| e.user_id.to_string() == user_id)
-            .map(|e| e.sku_id.clone())
-            .collect()
+        Vec::new()
     }
 }
 
-#[cfg(test)]
-mod tests {
+mod entitlements {
     use super::*;
 
-    #[tokio::test]
-    async fn grant_recovers_from_poison() {
-        let store = EntitlementStore::new(None);
-
-        let inner = store.inner();
-        let inner_clone = inner.clone();
-        let _ = std::thread::spawn(move || {
-            let _guard = inner_clone.write().unwrap();
-            panic!("poison");
-        })
-        .join();
-
-        let user = UserId::new_v4();
-        store.grant(user, "sku".to_string()).await;
-        let list = store.list(&user.to_string()).await;
-        assert_eq!(list, vec!["sku".to_string()]);
+    #[derive(Clone, Debug, PartialEq, DeriveEntityModel)]
+    #[sea_orm(
+        table_name = "entitlements_by_user",
+        primary_key = (user_id, sku_id)
+    )]
+    pub struct Model {
+        #[sea_orm(primary_key, auto_increment = false)]
+        pub user_id: Uuid,
+        #[sea_orm(primary_key, auto_increment = false)]
+        pub sku_id: String,
+        pub granted_at: DateTimeWithTimeZone,
     }
 
-    #[tokio::test]
-    async fn list_recovers_from_poison() {
-        let store = EntitlementStore::new(None);
-        let user = UserId::new_v4();
-        store.grant(user, "sku".to_string()).await;
+    #[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]
+    pub enum Relation {}
 
-        let inner = store.inner();
-        let inner_clone = inner.clone();
-        let _ = std::thread::spawn(move || {
-            let _guard = inner_clone.write().unwrap();
-            panic!("poison");
-        })
-        .join();
-
-        let list = store.list(&user.to_string()).await;
-        assert_eq!(list, vec!["sku".to_string()]);
-    }
+    impl ActiveModelBehavior for ActiveModel {}
 }
+
+mod purchases {
+    use sea_orm::entity::prelude::*;
+
+    #[derive(Clone, Debug, PartialEq, DeriveEntityModel)]
+    #[sea_orm(table_name = "purchases_by_user")]
+    pub struct Model {
+        #[sea_orm(primary_key)]
+        pub id: i32,
+        pub user_id: Uuid,
+        pub sku_id: String,
+        pub purchased_at: DateTimeWithTimeZone,
+    }
+
+    #[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]
+    pub enum Relation {}
+
+    impl ActiveModelBehavior for ActiveModel {}
+}
+


### PR DESCRIPTION
## Summary
- add SeaORM models for entitlements and purchases
- replace in-memory entitlement store with DB-backed upserts and queries
- wire new entitlements and purchases tables into migrations

## Testing
- `npm run prettier`
- `cargo test -p server` *(fails: package `bigdecimal` is specified twice in the lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_68bfff5e09e48323b4f77a3df40b5a32