### PR TITLE
Use SeaORM ActiveModel for guest players

### DIFF
--- a/server/src/players.rs
+++ b/server/src/players.rs
@@ -1,0 +1,14 @@
+use sea_orm::entity::prelude::*;
+
+#[derive(Clone, Debug, PartialEq, DeriveEntityModel)]
+#[sea_orm(table_name = "players_by_id")]
+pub struct Model {
+    #[sea_orm(primary_key, auto_increment = false)]
+    pub id: String,
+    pub guest: bool,
+}
+
+#[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]
+pub enum Relation {}
+
+impl ActiveModelBehavior for ActiveModel {}


### PR DESCRIPTION
## Summary
- add SeaORM entity for `players_by_id`
- insert guest player via ActiveModel instead of manual SQL
- remove direct Statement usage

## Testing
- `npm run prettier`
- `cargo test -p server` *(fails: `analytics` crate compile errors)*

------
https://chatgpt.com/codex/tasks/task_e_68c00aaba7048323a4357b9bf9b58ec1