### PR TITLE
chore: drop redis support from server

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2058,11 +2058,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
 dependencies = [
  "bytes",
- "futures-core",
  "memchr",
- "pin-project-lite",
- "tokio",
- "tokio-util",
 ]
 
 [[package]]
@@ -5888,25 +5884,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a0d463f2884048e7153449a55166f91028d5b0ea53c79377099ce4e8cf0cf9bb"
 
 [[package]]
-name = "redis"
-version = "0.24.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c580d9cbbe1d1b479e8d67cf9daf6a62c957e6846048408b80b43ac3f6af84cd"
-dependencies = [
- "async-trait",
- "bytes",
- "combine",
- "futures-util",
- "itoa",
- "percent-encoding",
- "pin-project-lite",
- "ryu",
- "tokio",
- "tokio-util",
- "url",
-]
-
-[[package]]
 name = "redox_syscall"
 version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6782,7 +6759,6 @@ dependencies = [
  "postcard",
  "prometheus",
  "rand",
- "redis",
  "sea-orm",
  "serde",
  "serde_json",

--- a/crates/minigames/duck_hunt/server.rs
+++ b/crates/minigames/duck_hunt/server.rs
@@ -299,7 +299,6 @@ mod tests {
     #[tokio::test]
     async fn leaderboard_records_hit() {
         let tmp = tempfile::tempdir().unwrap();
-        std::env::set_var("ARENA_REDIS_URL", "redis://127.0.0.1/");
         let service = LeaderboardService::new("127.0.0.1:9042", tmp.path().into())
             .await
             .unwrap();
@@ -341,7 +340,6 @@ mod tests {
     #[tokio::test]
     async fn dispatches_analytics_events() {
         let tmp = tempfile::tempdir().unwrap();
-        std::env::set_var("ARENA_REDIS_URL", "redis://127.0.0.1/");
         let service = LeaderboardService::new("127.0.0.1:9042", tmp.path().into())
             .await
             .unwrap();

--- a/docs/Config.md
+++ b/docs/Config.md
@@ -47,10 +47,9 @@ provided when launching the server.
 
 ## Leaderboards
 
-| Env var                 | CLI flag            | Description                                  | Default |
-| ----------------------- | ------------------- | -------------------------------------------- | ------- |
-| `ARENA_REDIS_URL`       | `--redis-url`       | Redis URL for the top‑N cache **(required)** | -       |
-| `ARENA_LEADERBOARD_MAX` | `--leaderboard-max` | Maximum entries mirrored per leaderboard     | `100`   |
+| Env var                 | CLI flag            | Description                              | Default |
+| ----------------------- | ------------------- | ---------------------------------------- | ------- |
+| `ARENA_LEADERBOARD_MAX` | `--leaderboard-max` | Maximum entries mirrored per leaderboard | `100`   |
 
 ## Editor
 

--- a/docs/Leaderboards.md
+++ b/docs/Leaderboards.md
@@ -1,20 +1,18 @@
 # Leaderboards
 
-Arena's leaderboard service persists results in Scylla and mirrors the
-top standings in Redis for fast reads. Scores are tracked in three windows:
-**daily**, **weekly**, and **all_time**.
+Arena's leaderboard service persists results in Scylla. Scores are tracked in
+three windows: **daily**, **weekly**, and **all_time**.
 
 ## Configuration
 
-| Env var                 | CLI flag            | Description                                  | Default |
-| ----------------------- | ------------------- | -------------------------------------------- | ------- |
-| `ARENA_DB_URL`          | `--db-url`          | Scylla database URL                          | -       |
-| `ARENA_REDIS_URL`       | `--redis-url`       | Redis URL for the top‑N cache **(required)** | -       |
-| `ARENA_LEADERBOARD_MAX` | `--leaderboard-max` | Maximum entries mirrored per leaderboard     | `100`   |
+| Env var                 | CLI flag            | Description                              | Default |
+| ----------------------- | ------------------- | ---------------------------------------- | ------- |
+| `ARENA_DB_URL`          | `--db-url`          | Scylla database URL                      | -       |
+| `ARENA_LEADERBOARD_MAX` | `--leaderboard-max` | Maximum entries mirrored per leaderboard | `100`   |
 
-Each score submission writes a run and windowed score to Scylla.
-The highest `ARENA_LEADERBOARD_MAX` scores for each window are maintained
-in Redis sorted sets for quick retrieval.
+Each score submission writes a run and windowed score to Scylla. The highest
+`ARENA_LEADERBOARD_MAX` scores for each window are maintained for quick
+retrieval.
 
 ## Usage
 

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -38,12 +38,6 @@ sea-orm = { version = "0.12", features=["sqlx-postgres","runtime-tokio-rustls","
 storage = { path = "../crates/storage" }
 migration = { path = "migration" }
 
-redis = { version = "0.24", optional = true, default-features = false, features = ["tokio-comp"] }
-
-[features]
-redis = ["dep:redis"]
-
-
 [dev-dependencies]
 tokio-tungstenite = "0.21"
 futures-util = "0.3"

--- a/server/src/leaderboard.rs
+++ b/server/src/leaderboard.rs
@@ -2,19 +2,19 @@ use std::sync::Arc;
 
 use axum::extract::ws::{Message, WebSocket, WebSocketUpgrade};
 use axum::{
+    Json, Router,
     extract::{Path, Query, State},
     http::StatusCode,
     response::IntoResponse,
     routing::{get, post},
-    Json, Router,
 };
 use chrono::Utc;
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
 use ::leaderboard::{
-    models::{LeaderboardWindow, Run, Score},
     LeaderboardService,
+    models::{LeaderboardWindow, Run, Score},
 };
 use analytics::Event;
 
@@ -227,8 +227,8 @@ mod tests {
     };
     use ::payments::{Catalog, Sku};
     use analytics::Analytics;
-    use axum::extract::{Path, State};
     use axum::Json;
+    use axum::extract::{Path, State};
     use leaderboard::models::LeaderboardWindow;
     use std::path::PathBuf;
 
@@ -244,7 +244,6 @@ mod tests {
     #[tokio::test]
     #[ignore]
     async fn post_run_rejects_malformed_base64() {
-        std::env::set_var("ARENA_REDIS_URL", "redis://127.0.0.1/");
         let cfg = smtp_cfg();
         let email = Arc::new(EmailService::new(cfg.clone()).unwrap());
         let leaderboard =
@@ -275,17 +274,18 @@ mod tests {
 
         let status = post_run(Path(leaderboard_id), State(state.clone()), Json(payload)).await;
         assert_eq!(status, StatusCode::BAD_REQUEST);
-        assert!(state
-            .leaderboard
-            .get_scores(leaderboard_id, LeaderboardWindow::AllTime)
-            .await
-            .is_empty());
+        assert!(
+            state
+                .leaderboard
+                .get_scores(leaderboard_id, LeaderboardWindow::AllTime)
+                .await
+                .is_empty()
+        );
     }
 
     #[tokio::test]
     #[ignore]
     async fn post_run_accepts_valid_payload() {
-        std::env::set_var("ARENA_REDIS_URL", "redis://127.0.0.1/");
         let cfg = smtp_cfg();
         let email = Arc::new(EmailService::new(cfg.clone()).unwrap());
         let leaderboard =
@@ -326,7 +326,6 @@ mod tests {
     #[tokio::test]
     #[ignore]
     async fn post_run_rejects_oversized_payload() {
-        std::env::set_var("ARENA_REDIS_URL", "redis://127.0.0.1/");
         let cfg = smtp_cfg();
         let email = Arc::new(EmailService::new(cfg.clone()).unwrap());
         let leaderboard =
@@ -356,17 +355,18 @@ mod tests {
 
         let status = post_run(Path(leaderboard_id), State(state.clone()), Json(payload)).await;
         assert_eq!(status, StatusCode::PAYLOAD_TOO_LARGE);
-        assert!(state
-            .leaderboard
-            .get_scores(leaderboard_id, LeaderboardWindow::AllTime)
-            .await
-            .is_empty());
+        assert!(
+            state
+                .leaderboard
+                .get_scores(leaderboard_id, LeaderboardWindow::AllTime)
+                .await
+                .is_empty()
+        );
     }
 
     #[tokio::test]
     #[ignore]
     async fn post_run_rejects_invalid_score() {
-        std::env::set_var("ARENA_REDIS_URL", "redis://127.0.0.1/");
         let cfg = smtp_cfg();
         let email = Arc::new(EmailService::new(cfg.clone()).unwrap());
         let leaderboard =
@@ -397,17 +397,18 @@ mod tests {
 
         let status = post_run(Path(leaderboard_id), State(state.clone()), Json(payload)).await;
         assert_eq!(status, StatusCode::BAD_REQUEST);
-        assert!(state
-            .leaderboard
-            .get_scores(leaderboard_id, LeaderboardWindow::AllTime)
-            .await
-            .is_empty());
+        assert!(
+            state
+                .leaderboard
+                .get_scores(leaderboard_id, LeaderboardWindow::AllTime)
+                .await
+                .is_empty()
+        );
     }
 
     #[tokio::test]
     #[ignore]
     async fn verify_endpoint_marks_score_verified() {
-        std::env::set_var("ARENA_REDIS_URL", "redis://127.0.0.1/");
         let cfg = smtp_cfg();
         let email = Arc::new(EmailService::new(cfg.clone()).unwrap());
         let leaderboard =

--- a/server/src/room.rs
+++ b/server/src/room.rs
@@ -287,11 +287,7 @@ pub struct RoomManager {
 }
 
 impl RoomManager {
-    pub fn new(
-        leaderboard: LeaderboardService,
-        shard_id: String,
-        addr: String,
-    ) -> Self {
+    pub fn new(leaderboard: LeaderboardService, shard_id: String, addr: String) -> Self {
         let registry = Arc::new(crate::shard::MemoryShardRegistry::new());
         Self::with_registry(leaderboard, registry, shard_id, addr)
     }
@@ -372,7 +368,6 @@ mod tests {
     use tokio::sync::mpsc;
 
     async fn test_room() -> Room {
-        std::env::set_var("ARENA_REDIS_URL", "redis://127.0.0.1/");
         let leaderboard =
             ::leaderboard::LeaderboardService::new("127.0.0.1:9042", PathBuf::from("replays"))
                 .await

--- a/server/src/shard.rs
+++ b/server/src/shard.rs
@@ -55,33 +55,6 @@ impl ShardRegistry for MemoryShardRegistry {
     }
 }
 
-#[cfg(feature = "redis")]
-pub struct RedisShardRegistry {
-    client: redis::Client,
-}
-
-#[cfg(feature = "redis")]
-impl RedisShardRegistry {
-    pub fn new(client: redis::Client) -> Self {
-        Self { client }
-    }
-}
-
-#[cfg(feature = "redis")]
-impl ShardRegistry for RedisShardRegistry {
-    fn register(&self, _shard: ShardInfo) {
-        unimplemented!()
-    }
-
-    fn heartbeat(&self, _shard_id: &str, _load: usize) {
-        unimplemented!()
-    }
-
-    fn least_loaded(&self) -> Option<ShardInfo> {
-        unimplemented!()
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -91,14 +64,11 @@ mod tests {
     #[tokio::test]
     #[ignore]
     async fn chooses_least_loaded_shard() {
-        std::env::set_var("ARENA_REDIS_URL", "redis://127.0.0.1/");
         let registry = Arc::new(MemoryShardRegistry::new());
-        let leaderboard = ::leaderboard::LeaderboardService::new(
-            "127.0.0.1:9042",
-            PathBuf::from("replays"),
-        )
-        .await
-        .unwrap();
+        let leaderboard =
+            ::leaderboard::LeaderboardService::new("127.0.0.1:9042", PathBuf::from("replays"))
+                .await
+                .unwrap();
         let _s1 = room::RoomManager::with_registry(
             leaderboard.clone(),
             registry.clone(),

--- a/server/src/tests.rs
+++ b/server/src/tests.rs
@@ -20,7 +20,6 @@ use std::path::PathBuf;
 use std::sync::Arc;
 
 async fn leaderboard_service() -> ::leaderboard::LeaderboardService {
-    std::env::set_var("ARENA_REDIS_URL", "redis://127.0.0.1/");
     ::leaderboard::LeaderboardService::new("127.0.0.1:9042", PathBuf::from("replays"))
         .await
         .unwrap()


### PR DESCRIPTION
## Summary
- remove optional Redis dependency and feature flag
- strip ARENA_REDIS_URL usage from server tests and duck hunt minigame
- update configuration docs to omit Redis references

## Testing
- `cargo check -p server` *(fails: expected identifier in crates/analytics/src/lib.rs)*
- `cargo test -p server` *(fails: expected identifier in crates/analytics/src/lib.rs)*
- `npm run prettier`


------
https://chatgpt.com/codex/tasks/task_e_68c00d36a6ac8323bf547b0b5923f56b