### PR TITLE
docs: document PostgreSQL and SeaORM persistence

### DIFF
--- a/docs/Config.md
+++ b/docs/Config.md
@@ -2,7 +2,8 @@
 
 Arena is configured through environment variables prefixed with `ARENA_` or
 equivalent CLI flags. `ARENA_BIND_ADDR` or the `--bind-addr` flag must be
-provided when launching the server.
+provided when launching the server. Arena uses PostgreSQL with SeaORM for data
+persistence.
 
 ## Server
 
@@ -10,7 +11,7 @@ provided when launching the server.
 | ----------------------- | ------------------- | -------------------------------------------- | -------------------- |
 | `ARENA_BIND_ADDR`       | `--bind-addr`       | Address to bind the server to **(required)** | -                    |
 | `ARENA_PUBLIC_BASE_URL` | `--public-base-url` | Public base URL of the server                | -                    |
-| `ARENA_DB_URL`          | `--db-url`          | Scylla database URL                          | -                    |
+| `ARENA_DB_URL`          | `--db-url`          | PostgreSQL database URL                      | -                    |
 | `ARENA_CSP`             | `--csp`             | Content Security Policy header value         | `default-src 'self'` |
 
 ## RTC

--- a/docs/Leaderboards.md
+++ b/docs/Leaderboards.md
@@ -1,16 +1,18 @@
 # Leaderboards
 
-Arena's leaderboard service persists results in Scylla. Scores are tracked in
-three windows: **daily**, **weekly**, and **all_time**.
+Arena's leaderboard service persists results in PostgreSQL using SeaORM as the
+persistence layer. Scores are tracked in three windows: **daily**, **weekly**,
+and **all_time**.
 
 ## Configuration
 
 | Env var                 | CLI flag            | Description                              | Default |
 | ----------------------- | ------------------- | ---------------------------------------- | ------- |
-| `ARENA_DB_URL`          | `--db-url`          | Scylla database URL                      | -       |
+| `ARENA_DB_URL`          | `--db-url`          | PostgreSQL database URL                  | -       |
 | `ARENA_LEADERBOARD_MAX` | `--leaderboard-max` | Maximum entries mirrored per leaderboard | `100`   |
 
-Each score submission writes a run and windowed score to Scylla. The highest
+Each score submission writes a run and windowed score to PostgreSQL via
+SeaORM. The highest
 `ARENA_LEADERBOARD_MAX` scores for each window are maintained for quick
 retrieval.
 

--- a/docs/Purchases.md
+++ b/docs/Purchases.md
@@ -1,7 +1,8 @@
 # Purchases
 
 Arena uses an OTP-based entitlement system. After a user signs in with a one-time
-password, the client can claim items directly from the server.
+password, the client can claim items directly from the server. Entitlements are
+stored in PostgreSQL via SeaORM.
 
 ## Catalog
 
@@ -22,7 +23,7 @@ curl http://localhost:3000/store
         -d '{"sku":"duck_hunt"}'
    ```
    The server verifies the session and records the entitlement in its
-   Scylla-backed store.
+   PostgreSQL-backed store using SeaORM.
 3. The entitlement is persisted server-side and can be queried later.
 
 ## Entitlements


### PR DESCRIPTION
## Summary
- replace Scylla mentions with PostgreSQL
- note SeaORM as the persistence layer
- clarify env var tables and remove Redis references

## Testing
- `npm run prettier`
- `npm test`
- `cargo test` *(fails: error: expected identifier … DeriveEntityModel)*

------
https://chatgpt.com/codex/tasks/task_e_68c01365bc34832392208d14995b50c8