### PR TITLE
feat: expand analytics and config

### DIFF
--- a/docs/Analytics.md
+++ b/docs/Analytics.md
@@ -5,19 +5,23 @@ optionally be forwarded to PostHog or exported via OpenTelemetry metrics.
 
 ## Configuration
 
-| Env var                   | CLI flag              | Description                                    | Default |
-| ------------------------- | --------------------- | ---------------------------------------------- | ------- |
-| `ARENA_POSTHOG_KEY`       | `--posthog-key`       | PostHog API key (optional sink)                | -       |
-| `ARENA_ANALYTICS_OPT_OUT` | `--analytics-opt-out` | Disable analytics regardless of other settings | `false` |
-| `ARENA_METRICS_ADDR`      | `--metrics-addr`      | OTLP metrics export address                    | -       |
+| Env var                         | CLI flag                    | Description                                    | Default |
+| ------------------------------- | --------------------------- | ---------------------------------------------- | ------- |
+| `ARENA_ANALYTICS_LOCAL`         | `--analytics-local`         | Store analytics events locally                 | `false` |
+| `ARENA_POSTHOG_KEY`             | `--posthog-key`             | PostHog API key (optional sink)                | -       |
+| `ARENA_POSTHOG_URL`             | `--posthog-url`             | PostHog endpoint URL                           | -       |
+| `ARENA_ANALYTICS_OPT_OUT`       | `--analytics-opt-out`       | Disable analytics regardless of other settings | `false` |
+| `ARENA_ANALYTICS_OTLP_ENDPOINT` | `--analytics-otlp-endpoint` | OTLP metrics export address                    | -       |
 
 ## Usage
 
 Provide a PostHog key and run the server:
 
 ```bash
+ARENA_ANALYTICS_LOCAL=true \
 ARENA_POSTHOG_KEY=phc_yourkey \
-ARENA_METRICS_ADDR=127.0.0.1:4317 \
+ARENA_POSTHOG_URL=https://app.posthog.com/capture/ \
+ARENA_ANALYTICS_OTLP_ENDPOINT=127.0.0.1:4317 \
 cargo run -p server
 ```
 

--- a/docs/Config.md
+++ b/docs/Config.md
@@ -22,16 +22,19 @@ persistence.
 
 ## Analytics
 
-| Env var                   | CLI flag              | Description                                    | Default |
-| ------------------------- | --------------------- | ---------------------------------------------- | ------- |
-| `ARENA_ANALYTICS_OPT_OUT` | `--analytics-opt-out` | Disable analytics regardless of other settings | `false` |
-| `ARENA_POSTHOG_KEY`       | `--posthog-key`       | PostHog API key (enables analytics)            | -       |
+| Env var                         | CLI flag                    | Description                                    | Default |
+| ------------------------------- | --------------------------- | ---------------------------------------------- | ------- |
+| `ARENA_ANALYTICS_LOCAL`         | `--analytics-local`         | Store analytics events locally                 | `false` |
+| `ARENA_POSTHOG_KEY`             | `--posthog-key`             | PostHog API key (enables analytics)            | -       |
+| `ARENA_POSTHOG_URL`             | `--posthog-url`             | PostHog endpoint URL                           | -       |
+| `ARENA_ANALYTICS_OPT_OUT`       | `--analytics-opt-out`       | Disable analytics regardless of other settings | `false` |
+| `ARENA_ANALYTICS_OTLP_ENDPOINT` | `--analytics-otlp-endpoint` | OTLP metrics export address                    | -       |
 
-## Metrics
+## Logging
 
-| Env var              | CLI flag         | Description                 | Default |
-| -------------------- | ---------------- | --------------------------- | ------- |
-| `ARENA_METRICS_ADDR` | `--metrics-addr` | OTLP metrics export address | -       |
+| Env var           | CLI flag      | Description              | Default |
+| ----------------- | ------------- | ------------------------ | ------- |
+| `ARENA_LOG_LEVEL` | `--log-level` | Log level for env_logger | -       |
 
 ## Email
 

--- a/server/src/config.rs
+++ b/server/src/config.rs
@@ -17,6 +17,12 @@ pub struct ConfigResponse {
     /// Whether analytics collection is opted out
     #[serde(default)]
     pub analytics_opt_out: bool,
+    /// Whether analytics events are stored locally
+    #[serde(default)]
+    pub analytics_local: bool,
+    /// PostHog endpoint (no key)
+    #[serde(default)]
+    pub posthog_url: Option<String>,
     /// Feature flags exposed to the client
     pub feature_flags: HashMap<String, bool>,
     /// ICE servers used for establishing peer connections
@@ -37,6 +43,8 @@ pub async fn get_config(Extension(cfg): Extension<ResolvedConfig>) -> Json<Confi
         api_base_url: cfg.public_base_url.clone(),
         analytics_enabled: cfg.analytics_enabled,
         analytics_opt_out: cfg.analytics_opt_out,
+        analytics_local: cfg.analytics_local,
+        posthog_url: cfg.posthog_url.clone(),
         feature_flags: cfg.feature_flags.clone(),
         ice_servers: cfg.ice_servers.clone(),
         enable_coop_coep: cfg.enable_coop_coep,


### PR DESCRIPTION
## Summary
- parse new analytics and logging environment variables
- expose non-secret analytics options via `/config.json`
- document analytics, OTLP endpoint, and log-level settings

## Testing
- `npm run prettier`
- `cargo test -p server` *(fails: feature `edition2024` is required)*

------
https://chatgpt.com/codex/tasks/task_e_68c03d06bb288323936a717a95a8f13e