### PR TITLE
Track mail outbox send status

### DIFF
--- a/server/migration/src/lib.rs
+++ b/server/migration/src/lib.rs
@@ -2,12 +2,17 @@ pub use sea_orm_migration::prelude::*;
 
 mod m0001_init;
 mod m0002_nodes;
+mod m0003_mail_outbox;
 
 pub struct Migrator;
 
 #[async_trait::async_trait]
 impl MigratorTrait for Migrator {
     fn migrations() -> Vec<Box<dyn MigrationTrait>> {
-        vec![Box::new(m0001_init::Migration), Box::new(m0002_nodes::Migration)]
+        vec![
+            Box::new(m0001_init::Migration),
+            Box::new(m0002_nodes::Migration),
+            Box::new(m0003_mail_outbox::Migration),
+        ]
     }
 }

--- a/server/migration/src/m0003_mail_outbox.rs
+++ b/server/migration/src/m0003_mail_outbox.rs
@@ -1,0 +1,42 @@
+use sea_orm_migration::prelude::*;
+
+#[derive(DeriveMigrationName)]
+pub struct Migration;
+
+#[async_trait::async_trait]
+impl MigrationTrait for Migration {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .alter_table(
+                Table::alter()
+                    .table(MailOutbox::Table)
+                    .add_column(
+                        ColumnDef::new(MailOutbox::SentAt)
+                            .timestamp_with_time_zone()
+                            .null(),
+                    )
+                    .add_column(ColumnDef::new(MailOutbox::Error).string().null())
+                    .to_owned(),
+            )
+            .await
+    }
+
+    async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .alter_table(
+                Table::alter()
+                    .table(MailOutbox::Table)
+                    .drop_column(MailOutbox::SentAt)
+                    .drop_column(MailOutbox::Error)
+                    .to_owned(),
+            )
+            .await
+    }
+}
+
+#[derive(Iden)]
+enum MailOutbox {
+    Table,
+    SentAt,
+    Error,
+}

--- a/server/src/email.rs
+++ b/server/src/email.rs
@@ -288,7 +288,7 @@ impl EmailService {
         }
     }
 
-    fn send_mail(&self, to: &str, subject: &str, body: &str) -> Result<(), EmailError> {
+    pub(crate) fn send_mail(&self, to: &str, subject: &str, body: &str) -> Result<(), EmailError> {
         if !Self::allowed(to)? {
             return Err(EmailError::RateLimited);
         }

--- a/server/src/entities.rs
+++ b/server/src/entities.rs
@@ -177,6 +177,8 @@ pub mod mail_outbox {
         pub subject: String,
         pub body: String,
         pub created_at: DateTimeUtc,
+        pub sent_at: Option<DateTimeUtc>,
+        pub error: Option<String>,
     }
     #[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]
     pub enum Relation {}

--- a/server/src/jobs.rs
+++ b/server/src/jobs.rs
@@ -1,15 +1,25 @@
-use std::time::Duration;
+use std::{sync::Arc, time::Duration};
 
 use chrono::{Duration as ChronoDuration, Utc};
 use sea_orm::sea_query::{LockBehavior, LockType, OnConflict};
 use sea_orm::{
-    ActiveValue::Set, ColumnTrait, DatabaseConnection, DbErr, EntityTrait, QueryFilter, QueryOrder,
-    QuerySelect, TransactionTrait,
+    ActiveValue::Set,
+    ColumnTrait,
+    DatabaseConnection,
+    DbErr,
+    EntityTrait,
+    QueryFilter,
+    QueryOrder,
+    QuerySelect,
+    TransactionTrait,
 };
 use serde_json::json;
 use uuid::Uuid;
 
-use crate::entities::{jobs, nodes};
+use crate::{
+    email::EmailService,
+    entities::{jobs, mail_outbox, nodes},
+};
 
 const MAX_ATTEMPTS: i32 = 5;
 
@@ -17,7 +27,7 @@ const HEARTBEAT_INTERVAL: Duration = Duration::from_secs(5);
 const LEADER_TIMEOUT: ChronoDuration = ChronoDuration::seconds(15);
 
 /// Run the background job runner.
-pub async fn run(db: DatabaseConnection) {
+pub async fn run(db: DatabaseConnection, email: Arc<EmailService>) {
     let node_id = Uuid::new_v4();
     let region = std::env::var("ARENA_REGION").unwrap_or_else(|_| "global".to_string());
     let mut interval = tokio::time::interval(HEARTBEAT_INTERVAL);
@@ -29,7 +39,7 @@ pub async fn run(db: DatabaseConnection) {
         }
         match is_leader(&db, node_id).await {
             Ok(true) => {
-                if let Err(e) = claim_and_run(&db).await {
+                if let Err(e) = claim_and_run(&db, email.clone()).await {
                     log::error!("job runner error: {e}");
                 }
             }
@@ -67,7 +77,7 @@ async fn is_leader(db: &DatabaseConnection, id: Uuid) -> Result<bool, DbErr> {
     Ok(matches!(leader, Some(n) if n.id == id))
 }
 
-async fn claim_and_run(db: &DatabaseConnection) -> Result<(), DbErr> {
+async fn claim_and_run(db: &DatabaseConnection, email: Arc<EmailService>) -> Result<(), DbErr> {
     let now = Utc::now();
     let txn = db.begin().await?;
     if let Some(job) = jobs::Entity::find()
@@ -79,12 +89,16 @@ async fn claim_and_run(db: &DatabaseConnection) -> Result<(), DbErr> {
     {
         let mut active: jobs::ActiveModel = job.into();
         active.status = Set(jobs::JobStatus::Running);
-        active.attempts = Set(active.attempts.unwrap_or_default() + 1);
+        let current_attempts = match active.attempts.clone() {
+            Set(v) => v,
+            _ => 0,
+        };
+        active.attempts = Set(current_attempts + 1);
         active.updated_at = Set(now);
         let job = jobs::Entity::update(active).exec(&txn).await?;
         txn.commit().await?;
 
-        let res = handle(job.clone()).await;
+        let res = handle(job.clone(), email.clone(), db).await;
         let mut active: jobs::ActiveModel = job.into();
         active.updated_at = Set(Utc::now());
         match res {
@@ -94,7 +108,10 @@ async fn claim_and_run(db: &DatabaseConnection) -> Result<(), DbErr> {
             Err(e) => {
                 let job_id = active.id.clone().unwrap();
                 log::error!("job {} failed: {e}", job_id);
-                let attempts = active.attempts.unwrap_or_default();
+                let attempts = match active.attempts.clone() {
+                    Set(v) => v,
+                    _ => 0,
+                };
                 if attempts >= MAX_ATTEMPTS {
                     active.status = Set(jobs::JobStatus::Failed);
                 } else {
@@ -110,8 +127,33 @@ async fn claim_and_run(db: &DatabaseConnection) -> Result<(), DbErr> {
     Ok(())
 }
 
-async fn handle(job: jobs::Model) -> anyhow::Result<()> {
+async fn handle(
+    job: jobs::Model,
+    email: Arc<EmailService>,
+    db: &DatabaseConnection,
+) -> anyhow::Result<()> {
     match job.kind.as_str() {
+        "send_mail" => {
+            let id: i64 = job.payload.parse()?;
+            let mail = mail_outbox::Entity::find_by_id(id)
+                .one(db)
+                .await?
+                .ok_or_else(|| anyhow::anyhow!("mail_outbox {id} not found"))?;
+            let mut active: mail_outbox::ActiveModel = mail.clone().into();
+            match email.send_mail(&mail.recipient, &mail.subject, &mail.body) {
+                Ok(_) => {
+                    active.sent_at = Set(Some(Utc::now()));
+                    active.error = Set(None);
+                    mail_outbox::Entity::update(active).exec(db).await?;
+                    Ok(())
+                }
+                Err(e) => {
+                    active.error = Set(Some(e.to_string()));
+                    mail_outbox::Entity::update(active).exec(db).await?;
+                    Err(anyhow::anyhow!(e.to_string()))
+                }
+            }
+        }
         "fail" => anyhow::bail!("intentional failure"),
         _ => {
             log::info!("ran job {}", job.id);

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -650,7 +650,7 @@ async fn run(cli: Cli) -> Result<()> {
     let state = Arc::new(setup(&config, smtp, posthog_key.clone()).await?);
 
     if let Some(db) = state.db.clone() {
-        tokio::spawn(jobs::run(db));
+        tokio::spawn(jobs::run(db, state.email.clone()));
     }
 
     let assets_service = get_service(ServeDir::new(&config.assets_dir)).layer(


### PR DESCRIPTION
## Summary
- extend mail_outbox entity with optional sent_at and error fields
- record email send outcome in background job
- add migration for new mail_outbox columns

## Testing
- `npm run prettier`
- `cargo test -p server` *(fails: the trait bound `fn(State<RcOrArc<...>>, ...) -> ... {request_handler}: Handler<_, _>` is not satisfied)*

------
https://chatgpt.com/codex/tasks/task_e_68c04f7e1c0083239646d6eaefb80974