### PR TITLE
Require ICE server configuration

### DIFF
--- a/server/src/config.rs
+++ b/server/src/config.rs
@@ -26,7 +26,6 @@ pub struct ConfigResponse {
     /// Feature flags exposed to the client
     pub feature_flags: HashMap<String, bool>,
     /// ICE servers used for establishing peer connections
-    #[serde(default)]
     pub ice_servers: Vec<IceServerConfig>,
     /// Whether COOP/COEP headers are enabled
     #[serde(default)]

--- a/server/src/tests.rs
+++ b/server/src/tests.rs
@@ -99,9 +99,13 @@ fn env_used_when_no_cli() {
 fn missing_bind_addr_errors() {
     unsafe {
         env::remove_var("ARENA_BIND_ADDR");
+        env::set_var("ARENA_RTC_ICE_SERVERS_JSON", "[]");
     }
     let cli = Cli::try_parse_from(["prog"]).unwrap();
     assert!(cli.config.clone().resolve().is_err());
+    unsafe {
+        env::remove_var("ARENA_RTC_ICE_SERVERS_JSON");
+    }
 }
 
 #[test]
@@ -143,6 +147,7 @@ async fn config_json_respects_cli_overrides() {
         env::set_var("ARENA_STATIC_DIR", "static");
         env::set_var("ARENA_ASSETS_DIR", "assets");
         env::set_var("ARENA_ANALYTICS_OPT_OUT", "false");
+        env::set_var("ARENA_RTC_ICE_SERVERS_JSON", "[]");
     }
     let cli = Cli::try_parse_from([
         "prog",
@@ -177,6 +182,7 @@ async fn config_json_respects_cli_overrides() {
         env::remove_var("ARENA_STATIC_DIR");
         env::remove_var("ARENA_ASSETS_DIR");
         env::remove_var("ARENA_ANALYTICS_OPT_OUT");
+        env::remove_var("ARENA_RTC_ICE_SERVERS_JSON");
     }
 }
 


### PR DESCRIPTION
## Summary
- require ARENA_RTC_ICE_SERVERS_JSON and parse when resolving config
- drop optional ICE server handling in public config output
- update server tests to provide ICE server JSON

## Testing
- `npm run prettier`
- `cargo test -p server` *(fails: the trait bound `request_handler` is not satisfied and `std::env::set_var` is unsafe)*

------
https://chatgpt.com/codex/tasks/task_e_68c056c3da0483239ed82b33550958cc