### PR TITLE
feat(server): switch to tracing

### DIFF
--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -13,8 +13,8 @@ net = { path = "../crates/net", features = ["webrtc"] }
 serde = { version = "1", features = ["derive"] }
 webrtc = "0.11"
 anyhow = "1"
-log = "0.4"
-env_logger = "0.11"
+tracing = "0.1"
+tracing-subscriber = { version = "0.3", features = ["env-filter", "json"] }
 clap = { version = "4", features = ["derive", "env"] }
 duck_hunt_server = { path = "../crates/minigames/duck_hunt" }
 glam = "0.24"

--- a/server/src/email.rs
+++ b/server/src/email.rs
@@ -199,7 +199,7 @@ impl EmailService {
         let tls_params = TlsParameters::builder(config.host.clone())
             .build()
             .map_err(|e| {
-                log::error!("failed to build TLS parameters: {e:?}");
+                tracing::error!("failed to build TLS parameters: {e:?}");
                 EmailError::Smtp(e.to_string())
             })?;
 
@@ -260,7 +260,7 @@ impl EmailService {
                         EMAIL_FAILED.inc();
                         EMAIL_LAST_ERROR.reset();
                         EMAIL_LAST_ERROR.with_label_values(&[&e]).set(1);
-                        log::error!("dead-letter to {:?}: {e}", msg.envelope().to());
+                        tracing::error!("dead-letter to {:?}: {e}", msg.envelope().to());
                     }
                 }
             }
@@ -284,7 +284,7 @@ impl EmailService {
     pub fn queue_mail(&self, email: Message) {
         EMAIL_QUEUED.inc();
         if self.sender.send(email).is_err() {
-            log::warn!("email queue disconnected");
+            tracing::warn!("email queue disconnected");
         }
     }
 
@@ -370,7 +370,7 @@ where
         match send().await {
             Ok(_) => return Ok(()),
             Err(e) => {
-                log::warn!(
+                tracing::warn!(
                     "failed to send email: {e}; retrying in {}ms",
                     delay.as_millis()
                 );
@@ -380,7 +380,7 @@ where
             }
         }
     }
-    log::warn!("giving up after {MAX_RETRIES} attempts");
+    tracing::warn!("giving up after {MAX_RETRIES} attempts");
     Err(last_err.expect("no error recorded"))
 }
 

--- a/server/src/tests.rs
+++ b/server/src/tests.rs
@@ -12,9 +12,9 @@ use webrtc::api::APIBuilder;
 use webrtc::api::media_engine::MediaEngine;
 use webrtc::peer_connection::configuration::RTCConfiguration;
 
-use crate::test_logger::{INIT, LOGGER};
+use crate::test_logger::{init, INIT, LOGGER};
 use purchases::{Catalog, Sku};
-use log::LevelFilter;
+use tracing::level_filters::LevelFilter;
 use std::path::PathBuf;
 use std::sync::Arc;
 
@@ -242,10 +242,7 @@ async fn websocket_signaling_completes_handshake() {
 #[tokio::test]
 #[serial]
 async fn websocket_signaling_invalid_sdp_logs_and_closes() {
-    INIT.call_once(|| {
-        log::set_logger(&LOGGER).unwrap();
-    });
-    log::set_max_level(LevelFilter::Warn);
+    INIT.call_once(|| init(LevelFilter::WARN));
     LOGGER.messages.lock().unwrap().clear();
 
     let cfg = smtp_cfg();
@@ -294,10 +291,7 @@ async fn websocket_signaling_invalid_sdp_logs_and_closes() {
 #[tokio::test]
 #[serial]
 async fn websocket_signaling_unexpected_binary_logs_and_closes() {
-    INIT.call_once(|| {
-        log::set_logger(&LOGGER).unwrap();
-    });
-    log::set_max_level(LevelFilter::Warn);
+    INIT.call_once(|| init(LevelFilter::WARN));
     LOGGER.messages.lock().unwrap().clear();
 
     let cfg = smtp_cfg();
@@ -346,10 +340,7 @@ async fn websocket_signaling_unexpected_binary_logs_and_closes() {
 #[tokio::test]
 #[serial]
 async fn websocket_logs_unexpected_messages_and_closes() {
-    INIT.call_once(|| {
-        log::set_logger(&LOGGER).unwrap();
-    });
-    log::set_max_level(LevelFilter::Warn);
+    INIT.call_once(|| init(LevelFilter::WARN));
     LOGGER.messages.lock().unwrap().clear();
 
     let cfg = smtp_cfg();


### PR DESCRIPTION
## Summary
- replace log/env_logger with tracing
- update server modules to use tracing macros
- add test tracing subscriber

## Testing
- `npm run prettier`
- `cargo clippy -p server --all-targets` *(fails: toolchain installation did not complete)*
- `cargo test -p server --no-run` *(fails: toolchain installation did not complete)*

------
https://chatgpt.com/codex/tasks/task_e_68c05dbded2083238dd70611e6c4c9b8