### PR TITLE
Remove mutable data channel config in net crate

### DIFF
--- a/crates/net/src/client.rs
+++ b/crates/net/src/client.rs
@@ -55,7 +55,7 @@ impl ClientConnector {
         m.register_default_codecs()?;
         let api = APIBuilder::new().with_media_engine(m).build();
         let pc = api.new_peer_connection(RTCConfiguration::default()).await?;
-        let mut cfg = RTCDataChannelInit {
+        let cfg = RTCDataChannelInit {
             ordered: Some(false),
             max_retransmits: Some(0),
             ..Default::default()


### PR DESCRIPTION
## Summary
- avoid mutable RTCDataChannelInit in client

## Testing
- `npm run prettier`
- `cargo clippy -p net`

------
https://chatgpt.com/codex/tasks/task_e_68c07689adbc8323889a51e667414d35