### PR TITLE
feat(analytics): add optional bevy resource support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -181,6 +181,7 @@ dependencies = [
 name = "analytics"
 version = "0.1.0"
 dependencies = [
+ "bevy_ecs",
  "chrono",
  "httpmock",
  "opentelemetry",

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -34,7 +34,7 @@ null_module = { path = "../crates/minigames/null_module" }
 physics = { path = "crates/physics" }
 editor = { path = "../crates/editor" }
 render = { path = "../crates/render" }
-analytics = { path = "../crates/analytics" }
+analytics = { path = "../crates/analytics", features = ["bevy-resource"] }
 purchases = { path = "../crates/purchases" }
 platform-api = { path = "../crates/platform-api" }
 netcode = { path = "../crates/net", package = "net" }

--- a/client/crates/minigames/duck_hunt/Cargo.toml
+++ b/client/crates/minigames/duck_hunt/Cargo.toml
@@ -25,4 +25,4 @@ postcard = { version = "1", features = ["alloc"] }
 serde = { version = "1", features = ["derive"] }
 net = { path = "../../../../crates/net" }
 rand = "0.8"
-analytics = { path = "../../../../crates/analytics" }
+analytics = { path = "../../../../crates/analytics", features = ["bevy-resource"] }

--- a/crates/analytics/Cargo.toml
+++ b/crates/analytics/Cargo.toml
@@ -13,12 +13,14 @@ tokio = { version = "1", features = ["rt", "macros"] }
 chrono = { version = "0.4", features = ["serde"] }
 sea-orm = { version = "0.12", default-features = false, features = ["sqlx-postgres", "runtime-tokio-rustls", "macros", "with-uuid", "with-chrono", "with-json"] }
 uuid = { version = "1", features = ["serde", "v4"] }
+bevy_ecs = { version = "0.12", optional = true }
 
 [features]
 default = ["posthog", "otlp", "prometheus"]
 posthog = ["reqwest"]
 otlp = ["opentelemetry"]
 prometheus = ["dep:prometheus"]
+bevy-resource = ["bevy_ecs"]
 
 [dev-dependencies]
 httpmock = "0.7"

--- a/crates/analytics/src/lib.rs
+++ b/crates/analytics/src/lib.rs
@@ -14,10 +14,12 @@ use sea_orm::{
     entity::prelude::*,
     sea_query::{Alias, Expr, Func, OnConflict, PostgresQueryBuilder, Query, SimpleExpr},
 };
-use serde_json::{json, Value as JsonValue};
-use uuid::Uuid;
+use serde_json::{Value as JsonValue, json};
 use tokio::time::{Duration, interval};
+use uuid::Uuid;
 
+#[cfg(feature = "bevy-resource")]
+use bevy_ecs::system::Resource;
 #[cfg(feature = "otlp")]
 use opentelemetry::{KeyValue, global, metrics::Counter};
 #[cfg(feature = "prometheus")]
@@ -30,7 +32,6 @@ use std::sync::atomic::{AtomicU64, Ordering};
 
 const DEFAULT_MAX_EVENTS: usize = 10_000;
 const MAX_EVENTS_ENV_VAR: &str = "ARENA_ANALYTICS_MAX_EVENTS";
-
 
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]
 pub enum Event {
@@ -141,6 +142,7 @@ impl Event {
     }
 }
 
+#[cfg_attr(feature = "bevy-resource", derive(Resource))]
 #[derive(Clone)]
 pub struct Analytics {
     enabled: bool,
@@ -395,8 +397,8 @@ impl Analytics {
 }
 
 mod events {
-    use sea_orm::entity::prelude::*;
     use super::{JsonValue, Uuid};
+    use sea_orm::entity::prelude::*;
 
     #[derive(Clone, Debug, PartialEq, DeriveEntityModel)]
     #[sea_orm(table_name = "analytics_events")]


### PR DESCRIPTION
## Summary
- add optional `bevy_ecs` dependency and `bevy-resource` feature to analytics crate
- gate analytics `Resource` derive and import behind `bevy-resource` feature
- enable analytics `bevy-resource` feature for client and duck_hunt minigame

## Testing
- `npm run prettier`
- `cargo test -p analytics`
- `cargo check --manifest-path client/crates/minigames/duck_hunt/Cargo.toml`


------
https://chatgpt.com/codex/tasks/task_e_68c076816cdc8323ac725a8aeace385d