### PR TITLE
Add configurable email hashing salt

### DIFF
--- a/client/src/main.rs
+++ b/client/src/main.rs
@@ -24,7 +24,7 @@ static ALLOC: wee_alloc::WeeAlloc = wee_alloc::WeeAlloc::INIT;
 fn main() {
     let config = future::block_on(RuntimeConfig::load());
     let enabled = config.analytics_enabled && !config.analytics_opt_out;
-    let analytics = Analytics::new(enabled, None, None);
+    let analytics = Analytics::new(enabled, None, None, None);
     analytics.dispatch(Event::SessionStart);
     analytics.dispatch(Event::LevelStart { level: 1 });
     let mut entitlements: HashSet<String> =
@@ -58,7 +58,7 @@ use wasm_bindgen::prelude::*;
 pub async fn main() -> Result<(), JsValue> {
     let config = RuntimeConfig::load().await;
     let enabled = config.analytics_enabled && !config.analytics_opt_out;
-    let analytics = Analytics::new(enabled, None, None);
+    let analytics = Analytics::new(enabled, None, None, None);
     analytics.dispatch(Event::SessionStart);
     analytics.dispatch(Event::LevelStart { level: 1 });
     let mut entitlements: HashSet<String> =

--- a/crates/minigames/duck_hunt/server.rs
+++ b/crates/minigames/duck_hunt/server.rs
@@ -363,7 +363,7 @@ mod tests {
         let leaderboard_id = Uuid::new_v4();
         let player_id = Uuid::new_v4();
         let replay = b"shot".to_vec();
-        let analytics = Analytics::new(true, None, None);
+        let analytics = Analytics::new(true, None, None, None);
         let hit = handle_shot(
             &server,
             &service,

--- a/docs/Config.md
+++ b/docs/Config.md
@@ -50,6 +50,12 @@ persistence.
 | `ARENA_SMTP_PASS`       | `--smtp-pass`       | SMTP password                             | -       |
 | `ARENA_SMTP_TIMEOUT_MS` | `--smtp-timeout-ms` | Connection timeout in milliseconds        | `10000` |
 
+## Auth
+
+| Env var            | CLI flag       | Description                                           | Default |
+| ------------------ | -------------- | ----------------------------------------------------- | ------- |
+| `ARENA_EMAIL_SALT` | `--email-salt` | Salt used when hashing email addresses **(required)** | -       |
+
 ## Leaderboards
 
 | Env var                 | CLI flag            | Description                              | Default   |

--- a/server/src/leaderboard.rs
+++ b/server/src/leaderboard.rs
@@ -270,6 +270,7 @@ mod tests {
                 price_cents: 1000,
             }]),
             db: None,
+            email_salt: "salt".into(),
         });
 
         let leaderboard_id = Uuid::new_v4();
@@ -303,6 +304,7 @@ mod tests {
             leaderboard: leaderboard.clone(),
             catalog: Catalog::new(vec![]),
             db: None,
+            email_salt: "salt".into(),
         });
 
         let leaderboard_id = Uuid::new_v4();
@@ -342,6 +344,7 @@ mod tests {
             leaderboard: leaderboard.clone(),
             catalog: Catalog::new(vec![]),
             db: None,
+            email_salt: "salt".into(),
         });
 
         let leaderboard_id = Uuid::new_v4();
@@ -377,6 +380,7 @@ mod tests {
             leaderboard: leaderboard.clone(),
             catalog: Catalog::new(vec![]),
             db: None,
+            email_salt: "salt".into(),
         });
 
         let leaderboard_id = Uuid::new_v4();
@@ -413,6 +417,7 @@ mod tests {
             leaderboard: leaderboard.clone(),
             catalog: Catalog::new(vec![]),
             db: None,
+            email_salt: "salt".into(),
         });
 
         let leaderboard_id = Uuid::new_v4();

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -100,6 +100,8 @@ struct Config {
     rtc_ice_servers_json: Option<String>,
     #[arg(long, env = "ARENA_METRICS_ADDR")]
     metrics_addr: Option<SocketAddr>,
+    #[arg(long, env = "ARENA_EMAIL_SALT")]
+    email_salt: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -162,6 +164,7 @@ pub struct ResolvedConfig {
     pub analytics_local: bool,
     pub posthog_url: Option<String>,
     pub analytics_otlp_endpoint: Option<SocketAddr>,
+    pub email_salt: String,
 }
 
 impl Config {
@@ -214,6 +217,9 @@ impl Config {
             analytics_local: false,
             posthog_url: None,
             analytics_otlp_endpoint: None,
+            email_salt: self
+                .email_salt
+                .ok_or_else(|| anyhow!("ARENA_EMAIL_SALT not set"))?,
         })
     }
 }
@@ -227,6 +233,7 @@ pub(crate) struct AppState {
     leaderboard: ::leaderboard::LeaderboardService,
     catalog: Catalog,
     db: Option<DatabaseConnection>,
+    email_salt: String,
 }
 
 async fn ws_handler(State(state): State<Arc<AppState>>, ws: WebSocketUpgrade) -> impl IntoResponse {
@@ -625,6 +632,7 @@ async fn setup(
         leaderboard,
         catalog,
         db: Some(db),
+        email_salt: cfg.email_salt.clone(),
     })
 }
 

--- a/server/src/tests.rs
+++ b/server/src/tests.rs
@@ -63,6 +63,7 @@ async fn setup_succeeds_without_env_vars() {
         analytics_local: false,
         posthog_url: None,
         analytics_otlp_endpoint: None,
+        email_salt: "salt".into(),
     };
     assert!(setup(&cfg, smtp_cfg(), None).await.is_ok());
 }
@@ -104,11 +105,13 @@ fn missing_bind_addr_errors() {
     unsafe {
         env::remove_var("ARENA_BIND_ADDR");
         env::set_var("ARENA_RTC_ICE_SERVERS_JSON", "[]");
+        env::set_var("ARENA_EMAIL_SALT", "salt");
     }
     let cli = Cli::try_parse_from(["prog"]).unwrap();
     assert!(cli.config.clone().resolve().is_err());
     unsafe {
         env::remove_var("ARENA_RTC_ICE_SERVERS_JSON");
+        env::remove_var("ARENA_EMAIL_SALT");
     }
 }
 
@@ -152,6 +155,7 @@ async fn config_json_respects_cli_overrides() {
         env::set_var("ARENA_ASSETS_DIR", "assets");
         env::set_var("ARENA_ANALYTICS_OPT_OUT", "false");
         env::set_var("ARENA_RTC_ICE_SERVERS_JSON", "[]");
+        env::set_var("ARENA_EMAIL_SALT", "salt");
     }
     let cli = Cli::try_parse_from([
         "prog",
@@ -187,6 +191,7 @@ async fn config_json_respects_cli_overrides() {
         env::remove_var("ARENA_ASSETS_DIR");
         env::remove_var("ARENA_ANALYTICS_OPT_OUT");
         env::remove_var("ARENA_RTC_ICE_SERVERS_JSON");
+        env::remove_var("ARENA_EMAIL_SALT");
     }
 }
 
@@ -207,6 +212,7 @@ async fn websocket_signaling_completes_handshake() {
             price_cents: 1000,
         }]),
         db: None,
+        email_salt: "salt".into(),
     });
 
     let app = Router::new()
@@ -264,6 +270,7 @@ async fn websocket_signaling_invalid_sdp_logs_and_closes() {
             price_cents: 1000,
         }]),
         db: None,
+        email_salt: "salt".into(),
     });
 
     let app = Router::new()
@@ -313,6 +320,7 @@ async fn websocket_signaling_unexpected_binary_logs_and_closes() {
             price_cents: 1000,
         }]),
         db: None,
+        email_salt: "salt".into(),
     });
 
     let app = Router::new()
@@ -362,6 +370,7 @@ async fn websocket_logs_unexpected_messages_and_closes() {
             price_cents: 1000,
         }]),
         db: None,
+        email_salt: "salt".into(),
     });
 
     let app = Router::new()
@@ -405,6 +414,7 @@ async fn mail_test_defaults_to_from_address() {
             price_cents: 1000,
         }]),
         db: None,
+        email_salt: "salt".into(),
     });
 
     assert_eq!(
@@ -436,6 +446,7 @@ async fn mail_test_accepts_user_address_query() {
             price_cents: 1000,
         }]),
         db: None,
+        email_salt: "salt".into(),
     });
 
     assert_eq!(
@@ -474,6 +485,7 @@ async fn mail_test_accepts_user_address_body() {
             price_cents: 1000,
         }]),
         db: None,
+        email_salt: "salt".into(),
     });
 
     assert_eq!(
@@ -511,6 +523,7 @@ async fn mail_config_redacts_password() {
             price_cents: 1000,
         }]),
         db: None,
+        email_salt: "salt".into(),
     });
 
     let Json(redacted) = mail_config_handler(State(state)).await;
@@ -535,6 +548,7 @@ async fn admin_mail_config_route() {
             price_cents: 1000,
         }]),
         db: None,
+        email_salt: "salt".into(),
     });
 
     let app = Router::new()
@@ -576,6 +590,7 @@ async fn round_scores_appear_in_leaderboard() {
             price_cents: 1000,
         }]),
         db: None,
+        email_salt: "salt".into(),
     });
 
     let app = Router::new()


### PR DESCRIPTION
## Summary
- allow configuring email hash salt via `ARENA_EMAIL_SALT`/`--email-salt`
- use configured salt in email hashing
- document `ARENA_EMAIL_SALT` in server configuration docs

## Testing
- `npm run prettier`
- `cargo test -p server --no-run`

------
https://chatgpt.com/codex/tasks/task_e_68c08164cb808323aded8e5bc5135ba6