### PR TITLE
Ensure database connection at startup

### DIFF
--- a/crates/leaderboard/src/lib.rs
+++ b/crates/leaderboard/src/lib.rs
@@ -40,6 +40,10 @@ pub struct LeaderboardSnapshot {
 impl LeaderboardService {
     pub async fn new(database_url: &str, replay_dir: PathBuf) -> Result<Self> {
         let db = Database::connect(database_url).await?;
+        Self::with_db(db, replay_dir).await
+    }
+
+    pub async fn with_db(db: DatabaseConnection, replay_dir: PathBuf) -> Result<Self> {
         tokio::fs::create_dir_all(&replay_dir).await?;
         let (tx, _) = broadcast::channel(16);
         let max = std::env::var("ARENA_LEADERBOARD_MAX")


### PR DESCRIPTION
## Summary
- Make `AppState` always hold an active `DatabaseConnection`
- Fail fast when database URL is missing or connection cannot be established
- Simplify handlers by removing optional database logic
- Add `LeaderboardService::with_db` for tests

## Testing
- `npm run prettier`
- `cargo test` *(fails: The system library `alsa` required by crate `alsa-sys` was not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c08d74cde48323a33c24597ff60c88